### PR TITLE
Prevent inline execution drift and stabilize local test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ npm test
 
 `npm test` is the full local verification path, including the real VS Code extension-host suite. GitHub Actions stays lighter and only runs the unit tests plus packaging checks.
 
+On macOS, the VS Code extension-host portion of `npm test` may abort if it is launched from a restrictive sandbox. If that happens, rerun `npm run test:vscode` from a normal local shell/session outside the sandbox.
+
 Manual visual sessions:
 
 ```bash

--- a/media/r/rmd_notebooks_session.R
+++ b/media/r/rmd_notebooks_session.R
@@ -2,14 +2,21 @@ state_env <- new.env(parent = globalenv())
 
 options(menu.graphics = FALSE)
 
+rmd_notebooks_encode_line <- function(value) {
+  utils::URLencode(enc2utf8(value), reserved = TRUE)
+}
+
+rmd_notebooks_decode_line <- function(value) {
+  utils::URLdecode(value)
+}
+
 rmd_notebooks_emit_section <- function(name, lines) {
-  cat(sprintf("SECTION:%s:START\n", name))
+  cat(sprintf("SECTION:%s:COUNT:%d\n", name, length(lines)))
   if (length(lines) > 0) {
     for (line in lines) {
-      cat(line, "\n", sep = "")
+      cat("LINE:", rmd_notebooks_encode_line(line), "\n", sep = "")
     }
   }
-  cat(sprintf("SECTION:%s:END\n", name))
 }
 
 rmd_notebooks_render_html <- function(value) {
@@ -100,18 +107,14 @@ rmd_notebooks_request_prompt <- function(kind, prompt, choice_labels = character
     sprintf("ALLOW_EMPTY:%s", if (isTRUE(allow_empty)) "1" else "0"),
     sprintf("DEFAULT:%s", paste(default, collapse = " ")),
     sprintf("PLACEHOLDER:%s", paste(if (is.null(placeholder)) "" else placeholder, collapse = " ")),
-    "SECTION:TITLE:START",
-    if (!is.null(title) && nzchar(title)) title else character(),
-    "SECTION:TITLE:END",
-    "SECTION:PROMPT:START",
-    prompt,
-    "SECTION:PROMPT:END",
-    "SECTION:CHOICE_LABELS:START",
-    choice_labels,
-    "SECTION:CHOICE_LABELS:END",
-    "SECTION:CHOICE_VALUES:START",
-    choice_values,
-    "SECTION:CHOICE_VALUES:END",
+    sprintf("SECTION:TITLE:COUNT:%d", if (!is.null(title) && nzchar(title)) 1 else 0),
+    if (!is.null(title) && nzchar(title)) sprintf("LINE:%s", rmd_notebooks_encode_line(title)) else character(),
+    sprintf("SECTION:PROMPT:COUNT:%d", length(prompt)),
+    vapply(prompt, function(line) sprintf("LINE:%s", rmd_notebooks_encode_line(line)), character(1), USE.NAMES = FALSE),
+    sprintf("SECTION:CHOICE_LABELS:COUNT:%d", length(choice_labels)),
+    vapply(choice_labels, function(line) sprintf("LINE:%s", rmd_notebooks_encode_line(line)), character(1), USE.NAMES = FALSE),
+    sprintf("SECTION:CHOICE_VALUES:COUNT:%d", length(choice_values)),
+    vapply(choice_values, function(line) sprintf("LINE:%s", rmd_notebooks_encode_line(line)), character(1), USE.NAMES = FALSE),
     "RMD_NOTEBOOKS_PROMPT_END"
   )
   rmd_notebooks_emit_protocol_lines(protocol_lines)
@@ -312,20 +315,38 @@ repeat {
   plot_width_in <- readLines(con = stdin(), n = 1, warn = FALSE)
   plot_height_in <- readLines(con = stdin(), n = 1, warn = FALSE)
   plot_dpi <- readLines(con = stdin(), n = 1, warn = FALSE)
-  code_lines <- character()
+  code_count_line <- readLines(con = stdin(), n = 1, warn = FALSE)
 
-  repeat {
-    line <- readLines(con = stdin(), n = 1, warn = FALSE)
-    if (length(line) == 0 || identical(line, "RMD_NOTEBOOKS_END")) {
-      break
+  working_directory <- sub("^WORKDIR:", "", working_directory)
+  artifact_directory <- sub("^ARTIFACT_DIR:", "", artifact_directory)
+  plot_width_in <- sub("^PLOT_WIDTH:", "", plot_width_in)
+  plot_height_in <- sub("^PLOT_HEIGHT:", "", plot_height_in)
+  plot_dpi <- sub("^PLOT_DPI:", "", plot_dpi)
+  code_count <- suppressWarnings(as.integer(sub("^CODE_COUNT:", "", code_count_line)))
+  if (!is.finite(code_count) || code_count < 0) {
+    code_count <- 0L
+  }
+
+  code_lines <- character()
+  if (code_count > 0) {
+    for (index in seq_len(code_count)) {
+      line <- readLines(con = stdin(), n = 1, warn = FALSE)
+      if (length(line) == 0) {
+        break
+      }
+      code_lines <- c(code_lines, rmd_notebooks_decode_line(sub("^LINE:", "", line)))
     }
-    code_lines <- c(code_lines, line)
+  }
+
+  command_end <- readLines(con = stdin(), n = 1, warn = FALSE)
+  if (length(command_end) == 0 || !identical(command_end, "RMD_NOTEBOOKS_END")) {
+    next
   }
 
   result <- rmd_notebooks_execute(
     paste(code_lines, collapse = "\n"),
-    working_directory,
-    artifact_directory,
+    rmd_notebooks_decode_line(working_directory),
+    rmd_notebooks_decode_line(artifact_directory),
     suppressWarnings(as.numeric(plot_width_in)),
     suppressWarnings(as.numeric(plot_height_in)),
     suppressWarnings(as.numeric(plot_dpi))

--- a/src/document/chunkTypes.ts
+++ b/src/document/chunkTypes.ts
@@ -80,7 +80,7 @@ export type OutputItem =
   | ImageOutputItem
   | HtmlOutputItem;
 
-export type ChunkOutputStatus = "running" | "success" | "error";
+export type ChunkOutputStatus = "running" | "success" | "error" | "redirected";
 
 export interface ChunkOutputRecord {
   documentUri: string;

--- a/src/editor/outputChannelController.ts
+++ b/src/editor/outputChannelController.ts
@@ -32,6 +32,8 @@ export class OutputChannelController implements vscode.Disposable {
 
     if (record.status === "error") {
       void vscode.window.showErrorMessage(`Rmd Notebooks: ${getChunkDisplayName(chunk)} failed. See the Rmd Notebooks output panel.`);
+    } else if (record.status === "redirected") {
+      void vscode.window.setStatusBarMessage(`Rmd Notebooks: redirected ${getChunkDisplayName(chunk)} to the R terminal`, 3000);
     } else {
       void vscode.window.setStatusBarMessage(`Rmd Notebooks: finished ${getChunkDisplayName(chunk)}`, 2500);
     }

--- a/src/editor/outputPreview.ts
+++ b/src/editor/outputPreview.ts
@@ -89,6 +89,10 @@ function getStateLabel(record: ChunkOutputRecord): string | undefined {
     return "[running]";
   }
 
+  if (record.status === "redirected") {
+    return "[redirected]";
+  }
+
   if (record.stale) {
     return "[stale]";
   }

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -157,6 +157,8 @@ class RSession {
   private promptHandler: ((request: InteractivePromptRequest) => Promise<InteractivePromptResponse>) | undefined;
   private executionTimeout: NodeJS.Timeout | undefined;
   private executionTimeoutMs = 0;
+  private sessionReady = false;
+  private runtimeStderr = "";
 
   public constructor(rPath: string, scriptPath: string) {
     this.process = spawn(rPath, ["--slave", "--vanilla"], {
@@ -178,11 +180,18 @@ class RSession {
 
     this.lineReader.on("line", (line) => this.handleStdoutLine(line));
     this.process.stderr.on("data", (chunk) => {
-      this.startupErrors.push(chunk.toString());
-      if (this.pending) {
+      const text = chunk.toString();
+      if (!this.sessionReady) {
+        this.startupErrors.push(text);
+      } else if (this.pending) {
+        this.runtimeStderr += text;
+        return;
+      }
+
+      if (this.pending && !this.sessionReady) {
         this.clearExecutionTimeout();
         this.promptHandler = undefined;
-        this.pending.reject(new Error(chunk.toString()));
+        this.pending.reject(new Error(text));
         this.pending = undefined;
       }
     });
@@ -231,16 +240,18 @@ class RSession {
       this.pending = { resolve, reject };
       this.promptHandler = promptHandler;
       this.executionTimeoutMs = timeoutMs;
+      this.runtimeStderr = "";
       this.armExecutionTimeout();
       this.process.stdin.write(`${COMMAND_MARKER}\n`);
-      this.process.stdin.write(`${workingDirectory ?? ""}\n`);
-      this.process.stdin.write(`${artifactDirectory ?? ""}\n`);
-      this.process.stdin.write(`${plot?.widthInches ?? ""}\n`);
-      this.process.stdin.write(`${plot?.heightInches ?? ""}\n`);
-      this.process.stdin.write(`${plot?.dpi ?? ""}\n`);
-      this.process.stdin.write(code);
-      if (!code.endsWith("\n")) {
-        this.process.stdin.write("\n");
+      this.process.stdin.write(`WORKDIR:${encodeProtocolLine(workingDirectory ?? "")}\n`);
+      this.process.stdin.write(`ARTIFACT_DIR:${encodeProtocolLine(artifactDirectory ?? "")}\n`);
+      this.process.stdin.write(`PLOT_WIDTH:${plot?.widthInches ?? ""}\n`);
+      this.process.stdin.write(`PLOT_HEIGHT:${plot?.heightInches ?? ""}\n`);
+      this.process.stdin.write(`PLOT_DPI:${plot?.dpi ?? ""}\n`);
+      const codeLines = toProtocolLines(code);
+      this.process.stdin.write(`CODE_COUNT:${codeLines.length}\n`);
+      for (const line of codeLines) {
+        this.process.stdin.write(`LINE:${encodeProtocolLine(line)}\n`);
       }
       this.process.stdin.write(`${COMMAND_END_MARKER}\n`);
 
@@ -269,6 +280,7 @@ class RSession {
 
   private handleStdoutLine(line: string): void {
     if (line === READY_MARKER) {
+      this.sessionReady = true;
       clearTimeout(this.startTimer);
       this.readyResolve();
       return;
@@ -304,11 +316,16 @@ class RSession {
       }
 
       try {
-        pending.resolve(parseRawExecutionPayload(this.currentLines));
+        const payload = parseRawExecutionPayload(this.currentLines);
+        if (this.runtimeStderr.trim().length > 0) {
+          payload.stderr = payload.stderr.length > 0 ? `${payload.stderr}\n${this.runtimeStderr.trimEnd()}` : this.runtimeStderr.trimEnd();
+        }
+        pending.resolve(payload);
       } catch (error) {
         pending.reject(error instanceof Error ? error : new Error(String(error)));
       } finally {
         this.currentLines = [];
+        this.runtimeStderr = "";
       }
 
       return;
@@ -402,24 +419,18 @@ class RSession {
 function parseRawExecutionPayload(lines: string[]): RawExecutionPayload {
   const metadata = new Map<string, string>();
   const sections = new Map<string, string[]>();
-  let currentSection: string | undefined;
-
-  for (const line of lines) {
-    const sectionStart = line.match(/^SECTION:([A-Z_]+):START$/);
-    if (sectionStart) {
-      currentSection = sectionStart[1];
-      sections.set(currentSection, []);
-      continue;
-    }
-
-    const sectionEnd = line.match(/^SECTION:([A-Z_]+):END$/);
-    if (sectionEnd) {
-      currentSection = undefined;
-      continue;
-    }
-
-    if (currentSection) {
-      sections.get(currentSection)?.push(line);
+  
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const sectionHeader = line.match(/^SECTION:([A-Z_]+):COUNT:(\d+)$/);
+    if (sectionHeader) {
+      const [, sectionName, countText] = sectionHeader;
+      const count = Number.parseInt(countText, 10);
+      const values: string[] = [];
+      for (let offset = 0; offset < count && index + 1 < lines.length; offset += 1) {
+        values.push(decodeProtocolLine(stripProtocolLinePrefix(lines[++index])));
+      }
+      sections.set(sectionName, values);
       continue;
     }
 
@@ -443,24 +454,18 @@ function parseRawExecutionPayload(lines: string[]): RawExecutionPayload {
 function parsePromptRequest(lines: string[]): InteractivePromptRequest {
   const metadata = new Map<string, string>();
   const sections = new Map<string, string[]>();
-  let currentSection: string | undefined;
-
-  for (const line of lines) {
-    const sectionStart = line.match(/^SECTION:([A-Z_]+):START$/);
-    if (sectionStart) {
-      currentSection = sectionStart[1];
-      sections.set(currentSection, []);
-      continue;
-    }
-
-    const sectionEnd = line.match(/^SECTION:([A-Z_]+):END$/);
-    if (sectionEnd) {
-      currentSection = undefined;
-      continue;
-    }
-
-    if (currentSection) {
-      sections.get(currentSection)?.push(line);
+  
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const sectionHeader = line.match(/^SECTION:([A-Z_]+):COUNT:(\d+)$/);
+    if (sectionHeader) {
+      const [, sectionName, countText] = sectionHeader;
+      const count = Number.parseInt(countText, 10);
+      const values: string[] = [];
+      for (let offset = 0; offset < count && index + 1 < lines.length; offset += 1) {
+        values.push(decodeProtocolLine(stripProtocolLinePrefix(lines[++index])));
+      }
+      sections.set(sectionName, values);
       continue;
     }
 
@@ -497,6 +502,27 @@ function parsePromptRequest(lines: string[]): InteractivePromptRequest {
 
 function sanitizePromptValue(value?: string): string {
   return (value ?? "").replace(/\r?\n/g, " ");
+}
+
+function toProtocolLines(value: string): string[] {
+  const normalized = value.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function encodeProtocolLine(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function decodeProtocolLine(value: string): string {
+  return decodeURIComponent(value);
+}
+
+function stripProtocolLinePrefix(line: string): string {
+  return line.startsWith("LINE:") ? line.slice("LINE:".length) : "";
 }
 
 function escapeRString(value: string): string {

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -37,6 +37,8 @@ interface NotebookSnapshot {
   generatedAt: number;
 }
 
+type ExecuteCellOutcome = "completed" | "redirected";
+
 export class InlineChunksNotebookRuntime implements vscode.Disposable {
   private readonly snapshots = new Map<string, NotebookSnapshot>();
   private readonly outputsByDocument = new Map<string, Map<string, ChunkOutputRecord>>();
@@ -103,7 +105,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     const snapshot = await this.refreshNotebook(notebook);
     for (const entry of snapshot.chunks) {
-      await this.executeCell(notebook, entry.cell);
+      const outcome = await this.executeCell(notebook, entry.cell);
+      if (outcome === "redirected") {
+        break;
+      }
     }
   }
 
@@ -296,15 +301,15 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     await executor?.disposeSession?.(notebook.uri.toString());
   }
 
-  private async executeCell(notebook: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<void> {
+  private async executeCell(notebook: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<ExecuteCellOutcome> {
     if (cell.kind !== vscode.NotebookCellKind.Code) {
-      return;
+      return "completed";
     }
 
     const snapshot = await this.refreshNotebook(notebook);
     const entry = snapshot.chunks.find((candidate) => candidate.index === cell.index);
     if (!entry) {
-      return;
+      return "completed";
     }
 
     const outputs = await this.ensureOutputsLoaded(notebook.uri.toString());
@@ -312,7 +317,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     const chunkOptions = getChunkOptions(cell);
     const selected = await this.ensureControllerSelected(notebook);
     if (!selected) {
-      return;
+      return "completed";
     }
     const execution = this.controller.createNotebookCellExecution(notebook.cellAt(entry.index));
     execution.executionOrder = ++this.executionOrder;
@@ -327,7 +332,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       });
       execution.end(true, Date.now());
       void vscode.window.setStatusBarMessage(`Rmd Notebooks: skipped ${entry.chunk.label ?? "cell"} because eval=FALSE`, 2500);
-      return;
+      return "completed";
     }
 
     if (!executor) {
@@ -344,7 +349,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       });
       execution.end(false, Date.now());
       this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
-      return;
+      return "completed";
     }
 
     const runningRecord = createRecord(entry.chunk, "running", []);
@@ -378,11 +383,12 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       });
       execution.end(filteredResult.success, filteredResult.finishedAt);
       this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
+      return "completed";
     } catch (error) {
       if (error instanceof InteractiveExecutionError) {
-        const record = await this.handleInteractiveFallback(notebook, cell, entry.chunk, outputs, execution, error.message);
-        this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
-        return;
+        const fallback = await this.handleInteractiveFallback(notebook, cell, entry.chunk, outputs, execution, error.message);
+        this.outputChannelController.logRunCompleted(cell.document, entry.chunk, fallback.record);
+        return fallback.launchedTerminal ? "redirected" : "completed";
       }
 
       const record = createRecord(entry.chunk, "error", [
@@ -398,6 +404,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       });
       execution.end(false, Date.now());
       this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
+      return "completed";
     }
   }
 
@@ -652,7 +659,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     outputs: Map<string, ChunkOutputRecord>,
     execution: vscode.NotebookCellExecution,
     message: string
-  ): Promise<ChunkOutputRecord> {
+  ): Promise<{ record: ChunkOutputRecord; launchedTerminal: boolean }> {
     const behavior = vscode.workspace.getConfiguration("rmdNotebooks").get<"prompt" | "terminal" | "error">(
       "execution.interactiveFallbackBehavior",
       "prompt"
@@ -675,7 +682,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       }
     }
 
-    const record = createRecord(chunk, launchedTerminal ? "success" : "error", [
+    const record = createRecord(chunk, launchedTerminal ? "redirected" : "error", [
       {
         type: launchedTerminal ? "text" : "error",
         text: launchedTerminal
@@ -690,7 +697,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       await execution.replaceOutput(await createNotebookOutputs(record));
     });
     execution.end(launchedTerminal, Date.now());
-    return record;
+    return { record, launchedTerminal };
   }
 }
 

--- a/test/vscode/runVscodeTests.ts
+++ b/test/vscode/runVscodeTests.ts
@@ -1,44 +1,35 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { spawn } from "node:child_process";
-import { downloadAndUnzipVSCode } from "@vscode/test-electron";
+import { runTests } from "@vscode/test-electron";
 
 async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, "../../..");
   const extensionTestsPath = path.resolve(__dirname, "./suite/index");
   const workspacePath = await createWorkspaceFixture();
-  const downloadedExecutablePath = await downloadAndUnzipVSCode("1.112.0");
-  const appPath = resolveVsCodeAppPath(downloadedExecutablePath);
-  const cliPath = resolveVsCodeCliPath(appPath);
-  const testRuntimePath = await fs.mkdtemp(path.join(os.tmpdir(), "rmd-notebooks-vscode-runtime-"));
   const resultFilePath = path.resolve(__dirname, ".vscode-test-result.json");
   const proofFilePath = "/tmp/rmd-notebooks-vscode-proof.txt";
-  const userDataDir = path.join(testRuntimePath, "user-data");
-  const extensionsDir = path.join(testRuntimePath, "extensions");
 
   try {
-    await fs.mkdir(userDataDir, { recursive: true });
-    await fs.mkdir(extensionsDir, { recursive: true });
     await fs.rm(resultFilePath, { force: true });
     await fs.rm(proofFilePath, { force: true });
-    await launchVsCodeForTests(cliPath, [
-      "--wait",
-      "--disable-workspace-trust",
-      "--skip-welcome",
-      "--skip-release-notes",
-      "--disable-updates",
-      `--extensionTestsPath=${extensionTestsPath}`,
-      `--extensionDevelopmentPath=${extensionDevelopmentPath}`,
-      `--user-data-dir=${userDataDir}`,
-      `--extensions-dir=${extensionsDir}`,
-      workspacePath
-    ]);
+    await runTests({
+      version: "1.112.0",
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        workspacePath,
+        "--disable-workspace-trust",
+        "--skip-welcome",
+        "--skip-release-notes",
+        "--disable-updates"
+      ],
+      reuseMachineInstall: false
+    });
     await assertSuccessfulTestResult(resultFilePath, proofFilePath);
     console.log("VS Code integration tests passed.");
   } finally {
     await fs.rm(workspacePath, { recursive: true, force: true });
-    await fs.rm(testRuntimePath, { recursive: true, force: true });
     await fs.rm(resultFilePath, { force: true });
   }
 }
@@ -107,45 +98,6 @@ async function copyFixture(root: string, workspacePath: string, sourceName: stri
   const sourcePath = path.join(root, sourceName);
   const targetPath = path.join(workspacePath, targetName);
   await fs.copyFile(sourcePath, targetPath);
-}
-
-function resolveVsCodeAppPath(executablePath: string): string {
-  return path.resolve(executablePath, "../../..");
-}
-
-function resolveVsCodeCliPath(appPath: string): string {
-  return path.join(appPath, "Contents", "Resources", "app", "bin", "code");
-}
-
-async function launchVsCodeForTests(
-  cliPath: string,
-  args: string[]
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(cliPath, args, {
-      env: process.env
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-      process.stdout.write(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-      process.stderr.write(chunk);
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`VS Code test launcher exited with code ${code}.\nSTDERR:\n${stderr}\nSTDOUT:\n${stdout}`.trim()));
-        return;
-      }
-
-      resolve();
-    });
-  });
 }
 
 async function assertSuccessfulTestResult(resultFilePath: string, proofFilePath: string): Promise<void> {

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -405,6 +405,76 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(state.outputs.some((record) => record.outputTypes.includes("text")));
   });
 
+  it("stops run-all after redirecting an interactive chunk to the R terminal", async () => {
+    await writeFixture(
+      "interactive-run-all.qmd",
+      [
+        "# Interactive run all",
+        "",
+        "```{r waiting}",
+        "Sys.sleep(2)",
+        "```",
+        "",
+        "```{r later}",
+        "cat('after redirect\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 1000);
+    await updateTestSetting("execution.interactiveFallbackBehavior", "terminal");
+
+    const editor = await openNotebookEditor("interactive-run-all.qmd");
+
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+
+    await waitFor(() => {
+      const terminal = vscode.window.terminals.find((candidate) => candidate.name === "Rmd Notebooks R");
+      return terminal ?? undefined;
+    }, 15000);
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "redirected")
+    );
+
+    assert.equal(state.outputs.length, 1);
+    assert.equal(state.outputs[0].status, "redirected");
+    assert.ok(!state.outputChannelText.includes("after redirect"));
+  });
+
+  it("preserves protocol marker text in stdout", async () => {
+    await writeFixture(
+      "protocol-markers.qmd",
+      [
+        "# Protocol markers",
+        "",
+        "```{r markers}",
+        "cat('SECTION:HTML:COUNT:1\\n')",
+        "cat('RMD_NOTEBOOKS_END\\n')",
+        "cat('LINE:%2Ftmp%2Fplot.png\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("protocol-markers.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "success" && record.outputTypes.includes("text"))
+    );
+
+    assert.ok(state.outputChannelText.includes("SECTION:HTML:COUNT:1"));
+    assert.ok(state.outputChannelText.includes("RMD_NOTEBOOKS_END"));
+    assert.ok(
+      state.outputChannelText.includes("LINE:%2Ftmp%2Fplot.png") ||
+      state.outputChannelText.includes("LINE:/tmp/plot.png")
+    );
+  });
+
   it("handles menu() prompts inline with a selection picker", async () => {
     await writeFixture(
       "interactive-menu.qmd",


### PR DESCRIPTION
## Summary
- stop `Run All Chunks` after an interactive chunk is redirected to the R terminal so later cells do not continue in a mismatched inline session
- replace the fragile sentinel-based R session protocol with escaped/count-based framing so marker-like user output no longer corrupts parsing
- preserve runtime stderr as captured chunk output instead of treating any post-startup stderr bytes as an immediate executor failure
- modernize the VS Code extension-host test launcher and document the macOS sandbox caveat for local extension-host verification
- add integration coverage for terminal redirect behavior and protocol-marker preservation

## Why
Inline execution could report success after a terminal redirect and then continue subsequent cells against the wrong session state. The previous protocol was also vulnerable to collisions when user code printed internal marker strings.

## Testing
- `npm run compile`
- `npm run test:unit`
- `npm run test:vscode` (run outside the sandbox on macOS)
