### PR TITLE
[feat] Make R startup args configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.6
+
+- add configurable R startup arguments for inline chunk sessions and interactive R terminals
+- keep existing startup defaults while allowing `renv` projects to remove `--vanilla`
+- add a local `renv` startup smoke test via `npm run smoke:renv`
+
 ## 0.1.5
 
 - stop `Run All Chunks` after terminal redirection so later cells do not continue in a mismatched inline session

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ The notebook toolbar also exposes `Restart R Session` and `View Source`.
 
 Common prompt-style interactions such as `menu()` and `readline()` are handled inline with VS Code pickers and input boxes. If execution still appears to stall because a chunk wants unsupported interactive input, the extension can prompt to run that chunk in an integrated R terminal instead. This is controlled by `rmdNotebooks.execution.interactiveFallbackBehavior` and `rmdNotebooks.execution.interactiveFallbackTimeoutMs`.
 
+## Settings
+
+- `rmdNotebooks.r.path`: path to the R executable.
+- `rmdNotebooks.r.args`: arguments for inline chunk-execution R sessions. Defaults to `["--slave", "--vanilla"]`.
+- `rmdNotebooks.r.terminalArgs`: arguments for the interactive R terminal. Defaults to `["--vanilla"]`.
+
+For projects that rely on startup files, such as `renv` projects that auto-activate from `.Rprofile`, remove `--vanilla` from the relevant setting. For example:
+
+```json
+{
+  "rmdNotebooks.r.args": ["--slave"],
+  "rmdNotebooks.r.terminalArgs": []
+}
+```
+
 ## Development
 
 ```bash
@@ -79,6 +94,14 @@ npm test
 ```
 
 `npm test` is the full local verification path, including the real VS Code extension-host suite. GitHub Actions stays lighter and only runs the unit tests plus packaging checks.
+
+For changes that affect R startup behavior, run the local `renv` smoke test:
+
+```bash
+npm run smoke:renv
+```
+
+This creates a temporary `renv` project and verifies that the default `--vanilla` startup flags skip project activation while `renv`-compatible args allow the project library to load. The command may install `renv` into a temporary bootstrap library if it is not already available.
 
 On macOS, the VS Code extension-host portion of `npm test` may abort if it is launched from a restrictive sandbox. If that happens, rerun `npm run test:vscode` from a normal local shell/session outside the sandbox.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmd-notebooks-vscode",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmd-notebooks-vscode",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rmd-notebooks-vscode",
   "displayName": "Rmd Notebooks for VS Code",
   "description": "Open .Rmd and .qmd files as runnable R notebooks in VS Code and Positron.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "AlFontal",
   "author": "Alejandro Fontal",
   "license": "MIT",
@@ -120,6 +120,27 @@
           "default": "R",
           "description": "Path to the R executable used for chunk execution."
         },
+        "rmdNotebooks.r.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--slave",
+            "--vanilla"
+          ],
+          "description": "Arguments passed to the R executable when starting an inline chunk-execution session."
+        },
+        "rmdNotebooks.r.terminalArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--vanilla"
+          ],
+          "description": "Arguments passed to the R executable when starting the interactive R terminal."
+        },
         "rmdNotebooks.execution.interactiveFallbackTimeoutMs": {
           "type": "number",
           "default": 15000,
@@ -188,7 +209,8 @@
     "publish:precheck": "npm run test && npm run package:vsix",
     "test:unit": "npm run compile && mocha \"out/src/test/**/*.test.js\"",
     "test:vscode": "npm run compile && node ./out/test/vscode/runVscodeTests.js",
-    "test": "npm run test:unit && npm run test:vscode"
+    "test": "npm run test:unit && npm run test:vscode",
+    "smoke:renv": "Rscript --vanilla scripts/smoke_renv_startup.R"
   },
   "devDependencies": {
     "@vscode/vsce": "^3.6.0",

--- a/scripts/smoke_renv_startup.R
+++ b/scripts/smoke_renv_startup.R
@@ -1,0 +1,174 @@
+#!/usr/bin/env Rscript
+
+options(repos = c(CRAN = "https://cloud.r-project.org"))
+
+project_root <- tempfile("rmd-notebooks-renv-smoke-", tmpdir = Sys.getenv("TMPDIR", tempdir()))
+bootstrap_library <- file.path(project_root, "bootstrap-library")
+child_user_library <- file.path(project_root, "child-user-library")
+package_name <- paste0("rmdrenvsmoke", Sys.getpid())
+keep_project <- identical(Sys.getenv("RMD_NOTEBOOKS_KEEP_RENV_SMOKE"), "1")
+
+dir.create(project_root, recursive = TRUE)
+dir.create(bootstrap_library)
+dir.create(child_user_library)
+
+if (!keep_project) {
+  on.exit(unlink(project_root, recursive = TRUE, force = TRUE), add = TRUE)
+}
+
+message("Rmd Notebooks renv startup smoke")
+message("Project: ", project_root)
+
+.libPaths(c(bootstrap_library, .libPaths()))
+
+if (!requireNamespace("renv", quietly = TRUE)) {
+  message("Installing renv into a temporary bootstrap library...")
+  install.packages("renv", lib = bootstrap_library, quiet = TRUE)
+}
+
+setwd(project_root)
+renv::init(bare = TRUE, restart = FALSE)
+
+package_root <- file.path(project_root, package_name)
+dir.create(file.path(package_root, "R"), recursive = TRUE)
+writeLines(
+  c(
+    paste0("Package: ", package_name),
+    "Version: 0.0.1",
+    "Title: Rmd Notebooks renv Smoke Package",
+    "Description: Local package used by the Rmd Notebooks renv startup smoke test.",
+    "License: MIT",
+    "Encoding: UTF-8"
+  ),
+  file.path(package_root, "DESCRIPTION")
+)
+writeLines("export(smoke_value)", file.path(package_root, "NAMESPACE"))
+writeLines("smoke_value <- function() 'renv smoke package loaded'", file.path(package_root, "R", "smoke.R"))
+
+renv::install(package_root, prompt = FALSE)
+
+# Avoid leaking any parent renv activation state into the child R processes.
+Sys.unsetenv(c("RENV_PROJECT", "RENV_PROFILE", "RENV_ACTIVATE_PROJECT"))
+
+check_code <- paste(
+  sprintf("package_name <- '%s'", package_name),
+  "libpath_has_renv <- any(grepl('renv/library', .libPaths(), fixed = TRUE))",
+  "package_available <- requireNamespace(package_name, quietly = TRUE)",
+  "cat('LIBPATH_HAS_RENV=', libpath_has_renv, '\\n', sep = '')",
+  "cat('SMOKE_PACKAGE_AVAILABLE=', package_available, '\\n', sep = '')",
+  "if (package_available) {",
+  "  cat('SMOKE_PACKAGE_VALUE=', getExportedValue(package_name, 'smoke_value')(), '\\n', sep = '')",
+  "}",
+  sep = "\n"
+)
+
+format_args <- function(args) {
+  if (length(args) == 0) {
+    return("[]")
+  }
+
+  paste0("[", paste(sprintf("\"%s\"", args), collapse = ", "), "]")
+}
+
+cases <- list(
+  list(
+    label = "inline default",
+    config_args = c("--slave", "--vanilla"),
+    process_args = c("--slave", "--vanilla"),
+    expect_renv = FALSE,
+    expect_package = FALSE
+  ),
+  list(
+    label = "inline renv-compatible",
+    config_args = c("--slave"),
+    process_args = c("--slave"),
+    expect_renv = TRUE,
+    expect_package = TRUE
+  ),
+  list(
+    label = "terminal default",
+    config_args = c("--vanilla"),
+    process_args = c("--vanilla"),
+    expect_renv = FALSE,
+    expect_package = FALSE
+  ),
+  list(
+    label = "terminal empty args",
+    config_args = character(),
+    process_args = c("--no-save"),
+    expect_renv = TRUE,
+    expect_package = TRUE,
+    note = "non-interactive harness adds --no-save; a real VS Code terminal uses no args"
+  )
+)
+
+failures <- character()
+
+for (case in cases) {
+  output <- system2(
+    "R",
+    args = case$process_args,
+    input = check_code,
+    stdout = TRUE,
+    stderr = TRUE,
+    env = c(
+      paste0("R_LIBS_USER=", child_user_library),
+      "R_LIBS=",
+      "R_LIBS_SITE=",
+      paste0("R_PROFILE_USER=", file.path(project_root, ".Rprofile"))
+    )
+  )
+  status <- attr(output, "status")
+  if (is.null(status)) {
+    status <- 0
+  }
+
+  has_renv <- any(grepl("LIBPATH_HAS_RENV=TRUE", output, fixed = TRUE))
+  has_package <- any(grepl("SMOKE_PACKAGE_AVAILABLE=TRUE", output, fixed = TRUE))
+  args_label <- format_args(case$config_args)
+  note <- if (!is.null(case$note)) paste0(" (", case$note, ")") else ""
+
+  message("")
+  message(case$label, ": ", args_label, note)
+  message("  R exited with status: ", status)
+  message("  renv library active: ", has_renv)
+  message("  smoke package loadable: ", has_package)
+
+  if (status != 0) {
+    failures <- c(failures, sprintf("%s exited with status %s", case$label, status))
+    message(paste(paste0("  ", output), collapse = "\n"))
+    next
+  }
+
+  if (!identical(has_renv, case$expect_renv)) {
+    failures <- c(
+      failures,
+      sprintf("%s expected renv active=%s but got %s", case$label, case$expect_renv, has_renv)
+    )
+  }
+
+  if (!identical(has_package, case$expect_package)) {
+    failures <- c(
+      failures,
+      sprintf("%s expected smoke package loadable=%s but got %s", case$label, case$expect_package, has_package)
+    )
+  }
+}
+
+if (length(failures) > 0) {
+  message("")
+  message("renv startup smoke failed:")
+  message(paste(paste0("- ", failures), collapse = "\n"))
+  if (keep_project) {
+    message("Project kept at: ", project_root)
+  } else {
+    message("Set RMD_NOTEBOOKS_KEEP_RENV_SMOKE=1 to keep the temp project for debugging.")
+  }
+  quit(status = 1)
+}
+
+message("")
+message("renv startup smoke passed.")
+if (keep_project) {
+  message("Project kept at: ", project_root)
+}

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -12,6 +12,7 @@ import {
   InteractivePromptResponse
 } from "./executorTypes";
 import { InteractiveExecutionError } from "./executionErrors";
+import { getInlineRArgs } from "./rStartupArgs";
 
 const READY_MARKER = "RMD_NOTEBOOKS_READY";
 const RESULT_START_MARKER = "RMD_NOTEBOOKS_RESULT_START";
@@ -131,8 +132,9 @@ export class RExecutor implements Executor {
 
     const configuration = vscode.workspace.getConfiguration("rmdNotebooks");
     const rPath = configuration.get<string>("r.path", "R");
+    const rArgs = getInlineRArgs(configuration);
     const sessionScriptPath = path.join(this.extensionUri.fsPath, "media", "r", "rmd_notebooks_session.R");
-    const created = new RSession(rPath, sessionScriptPath);
+    const created = new RSession(rPath, rArgs, sessionScriptPath);
     this.sessions.set(documentUri, created);
     return created;
   }
@@ -160,8 +162,8 @@ class RSession {
   private sessionReady = false;
   private runtimeStderr = "";
 
-  public constructor(rPath: string, scriptPath: string) {
-    this.process = spawn(rPath, ["--slave", "--vanilla"], {
+  public constructor(rPath: string, rArgs: string[], scriptPath: string) {
+    this.process = spawn(rPath, rArgs, {
       stdio: "pipe"
     });
 

--- a/src/execution/rStartupArgs.ts
+++ b/src/execution/rStartupArgs.ts
@@ -1,0 +1,23 @@
+export const DEFAULT_INLINE_R_ARGS = ["--slave", "--vanilla"] as const;
+export const DEFAULT_TERMINAL_R_ARGS = ["--vanilla"] as const;
+
+interface ConfigurationReader {
+  get<T>(section: string, defaultValue: T): T | undefined;
+}
+
+export function getInlineRArgs(configuration: ConfigurationReader): string[] {
+  return getConfiguredArgs(configuration, "r.args", DEFAULT_INLINE_R_ARGS);
+}
+
+export function getTerminalRArgs(configuration: ConfigurationReader): string[] {
+  return getConfiguredArgs(configuration, "r.terminalArgs", DEFAULT_TERMINAL_R_ARGS);
+}
+
+function getConfiguredArgs(
+  configuration: ConfigurationReader,
+  section: string,
+  defaultValue: readonly string[]
+): string[] {
+  const configured = configuration.get<readonly string[]>(section, defaultValue);
+  return [...(configured ?? defaultValue)];
+}

--- a/src/execution/rTerminalRunner.ts
+++ b/src/execution/rTerminalRunner.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { getTerminalRArgs } from "./rStartupArgs";
 
 export class RTerminalRunner implements vscode.Disposable {
   private terminal: vscode.Terminal | undefined;
@@ -36,11 +37,12 @@ export class RTerminalRunner implements vscode.Disposable {
 
     const configuration = vscode.workspace.getConfiguration("rmdNotebooks");
     const rPath = configuration.get<string>("r.path", "R");
+    const rArgs = getTerminalRArgs(configuration);
 
     this.terminal = vscode.window.createTerminal({
       name: "Rmd Notebooks R",
       shellPath: rPath,
-      shellArgs: ["--vanilla"],
+      shellArgs: rArgs,
       cwd: workspaceFolder
     });
 

--- a/src/test/suite/rStartupArgs.test.ts
+++ b/src/test/suite/rStartupArgs.test.ts
@@ -1,0 +1,76 @@
+import { strict as assert } from "node:assert";
+import packageJson from "../../../package.json";
+import {
+  DEFAULT_INLINE_R_ARGS,
+  DEFAULT_TERMINAL_R_ARGS,
+  getInlineRArgs,
+  getTerminalRArgs
+} from "../../../src/execution/rStartupArgs";
+
+describe("rStartupArgs", () => {
+  it("defaults inline R args to the current inline behavior", () => {
+    const configuration = testConfiguration({});
+
+    assert.deepEqual(getInlineRArgs(configuration), ["--slave", "--vanilla"]);
+  });
+
+  it("defaults terminal R args to the current terminal behavior", () => {
+    const configuration = testConfiguration({});
+
+    assert.deepEqual(getTerminalRArgs(configuration), ["--vanilla"]);
+  });
+
+  it("uses configured inline R args instead of the default", () => {
+    const configuration = testConfiguration({
+      "r.args": ["--slave"]
+    });
+
+    assert.deepEqual(getInlineRArgs(configuration), ["--slave"]);
+  });
+
+  it("uses configured terminal R args instead of the default", () => {
+    const configuration = testConfiguration({
+      "r.terminalArgs": ["--quiet"]
+    });
+
+    assert.deepEqual(getTerminalRArgs(configuration), ["--quiet"]);
+  });
+
+  it("respects an empty inline R args array", () => {
+    const configuration = testConfiguration({
+      "r.args": []
+    });
+
+    assert.deepEqual(getInlineRArgs(configuration), []);
+  });
+
+  it("respects an empty terminal R args array", () => {
+    const configuration = testConfiguration({
+      "r.terminalArgs": []
+    });
+
+    assert.deepEqual(getTerminalRArgs(configuration), []);
+  });
+
+  it("returns a copy of default args", () => {
+    const configuration = testConfiguration({});
+
+    assert.notEqual(getInlineRArgs(configuration), DEFAULT_INLINE_R_ARGS);
+    assert.notEqual(getTerminalRArgs(configuration), DEFAULT_TERMINAL_R_ARGS);
+  });
+
+  it("contributes the inline and terminal settings with runtime defaults", () => {
+    const properties = packageJson.contributes.configuration.properties;
+
+    assert.deepEqual(properties["rmdNotebooks.r.args"].default, [...DEFAULT_INLINE_R_ARGS]);
+    assert.deepEqual(properties["rmdNotebooks.r.terminalArgs"].default, [...DEFAULT_TERMINAL_R_ARGS]);
+  });
+});
+
+function testConfiguration(values: Record<string, string[]>) {
+  return {
+    get<T>(section: string, defaultValue: T): T {
+      return (Object.prototype.hasOwnProperty.call(values, section) ? values[section] : defaultValue) as T;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Adds configurable R startup arguments for both inline chunk execution and the interactive R terminal.

- Adds `rmdNotebooks.r.args` for inline R sessions, defaulting to `["--slave", "--vanilla"]`.
- Adds `rmdNotebooks.r.terminalArgs` for terminal R sessions, defaulting to `["--vanilla"]`.
- Reads those settings only when creating a new R process or terminal, so existing sessions keep their current behavior until restart/dispose.
- Documents the `renv`-compatible configuration and bumps the extension version to `0.1.6`.
- Adds `npm run smoke:renv` as a local smoke test for real `renv` startup activation behavior.

## Why

Inline R execution previously always launched R with hardcoded startup flags. That preserved predictable execution, but it also prevented project startup files such as `.Rprofile` from running. In `renv` projects, that means the project library is not auto-activated and notebook chunks can fail to load project-installed packages. See #2 as it was @alpelito7's issue what prompted 

These changes keep the existing defaults for compatibility while giving users a supported way to remove `--vanilla` when they want normal R project startup behavior. I'll consider doing some (pretty harmless, IMO) breaking changes in a later release that remove `--vanilla` from the defaults.

## Validation

- `git diff --check`
- `npm run compile`
- `npm run test:unit` - 32 passing
- `npm run smoke:renv` - passed; verified default flags skip `renv/library` and `renv`-compatible args activate it
- `npm run test:vscode` - 17 passing on rerun

Didn't include the `smoke:renv` tests in CI to avoid unnecessary complexity and CRAN/renv dependency.

Closes #2 