### PR TITLE
[fix] Start inline R in the workspace folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: ci
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   test:
@@ -15,3 +20,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:unit
+      - run: npm run package:vsix
+        if: github.event_name == 'pull_request' && github.event.action == 'ready_for_review'
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request' && github.event.action == 'ready_for_review'
+        with:
+          name: rmd-notebooks-vsix
+          path: "*.vsix"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.7
+
+- start inline R sessions in the document workspace folder so `.Rprofile` can activate project tools such as `renv`
+- tighten the local `renv` smoke test so it depends on startup working directory instead of forcing `R_PROFILE_USER`
+
 ## 0.1.6
 
 - add configurable R startup arguments for inline chunk sessions and interactive R terminals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmd-notebooks-vscode",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmd-notebooks-vscode",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rmd-notebooks-vscode",
   "displayName": "Rmd Notebooks for VS Code",
   "description": "Open .Rmd and .qmd files as runnable R notebooks in VS Code and Positron.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "AlFontal",
   "author": "Alejandro Fontal",
   "license": "MIT",

--- a/scripts/smoke_renv_startup.R
+++ b/scripts/smoke_renv_startup.R
@@ -47,8 +47,8 @@ writeLines("smoke_value <- function() 'renv smoke package loaded'", file.path(pa
 
 renv::install(package_root, prompt = FALSE)
 
-# Avoid leaking any parent renv activation state into the child R processes.
-Sys.unsetenv(c("RENV_PROJECT", "RENV_PROFILE", "RENV_ACTIVATE_PROJECT"))
+# Avoid leaking parent startup state into the child R processes.
+Sys.unsetenv(c("RENV_PROJECT", "RENV_PROFILE", "RENV_ACTIVATE_PROJECT", "R_PROFILE", "R_PROFILE_USER"))
 
 check_code <- paste(
   sprintf("package_name <- '%s'", package_name),
@@ -75,6 +75,7 @@ cases <- list(
     label = "inline default",
     config_args = c("--slave", "--vanilla"),
     process_args = c("--slave", "--vanilla"),
+    startup_directory = project_root,
     expect_renv = FALSE,
     expect_package = FALSE
   ),
@@ -82,6 +83,7 @@ cases <- list(
     label = "inline renv-compatible",
     config_args = c("--slave"),
     process_args = c("--slave"),
+    startup_directory = project_root,
     expect_renv = TRUE,
     expect_package = TRUE
   ),
@@ -89,6 +91,7 @@ cases <- list(
     label = "terminal default",
     config_args = c("--vanilla"),
     process_args = c("--vanilla"),
+    startup_directory = project_root,
     expect_renv = FALSE,
     expect_package = FALSE
   ),
@@ -96,6 +99,7 @@ cases <- list(
     label = "terminal empty args",
     config_args = character(),
     process_args = c("--no-save"),
+    startup_directory = project_root,
     expect_renv = TRUE,
     expect_package = TRUE,
     note = "non-interactive harness adds --no-save; a real VS Code terminal uses no args"
@@ -105,19 +109,32 @@ cases <- list(
 failures <- character()
 
 for (case in cases) {
+  previous_directory <- getwd()
+  setwd(case$startup_directory)
   output <- system2(
-    "R",
-    args = case$process_args,
+    "env",
+    args = c(
+      "-u",
+      "R_PROFILE",
+      "-u",
+      "R_PROFILE_USER",
+      "-u",
+      "R_ENVIRON",
+      "-u",
+      "R_ENVIRON_USER",
+      "R",
+      case$process_args
+    ),
     input = check_code,
     stdout = TRUE,
     stderr = TRUE,
     env = c(
       paste0("R_LIBS_USER=", child_user_library),
       "R_LIBS=",
-      "R_LIBS_SITE=",
-      paste0("R_PROFILE_USER=", file.path(project_root, ".Rprofile"))
+      "R_LIBS_SITE="
     )
   )
+  setwd(previous_directory)
   status <- attr(output, "status")
   if (is.null(status)) {
     status <- 0

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -45,12 +45,13 @@ export class RExecutor implements Executor {
   }
 
   public async warmupSession(documentUri: string): Promise<void> {
-    const session = this.getOrCreateSession(documentUri);
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(documentUri))?.uri.fsPath;
+    const session = this.getOrCreateSession(documentUri, workspaceFolder);
     await session.ready();
   }
 
   public async executeChunk(context: ExecutionContext): Promise<ExecutionResult> {
-    const session = this.getOrCreateSession(context.documentUri);
+    const session = this.getOrCreateSession(context.documentUri, context.workspaceFolder);
     const timeoutMs = vscode.workspace.getConfiguration("rmdNotebooks").get<number>("execution.interactiveFallbackTimeoutMs", 15000);
     let payload: RawExecutionPayload;
 
@@ -124,7 +125,7 @@ export class RExecutor implements Executor {
     await Promise.all([...this.sessions.keys()].map((uri) => this.disposeSession(uri)));
   }
 
-  private getOrCreateSession(documentUri: string): RSession {
+  private getOrCreateSession(documentUri: string, workspaceFolder?: string): RSession {
     const existing = this.sessions.get(documentUri);
     if (existing) {
       return existing;
@@ -134,7 +135,7 @@ export class RExecutor implements Executor {
     const rPath = configuration.get<string>("r.path", "R");
     const rArgs = getInlineRArgs(configuration);
     const sessionScriptPath = path.join(this.extensionUri.fsPath, "media", "r", "rmd_notebooks_session.R");
-    const created = new RSession(rPath, rArgs, sessionScriptPath);
+    const created = new RSession(rPath, rArgs, sessionScriptPath, workspaceFolder);
     this.sessions.set(documentUri, created);
     return created;
   }
@@ -162,9 +163,10 @@ class RSession {
   private sessionReady = false;
   private runtimeStderr = "";
 
-  public constructor(rPath: string, rArgs: string[], scriptPath: string) {
+  public constructor(rPath: string, rArgs: string[], scriptPath: string, startupDirectory?: string) {
     this.process = spawn(rPath, rArgs, {
-      stdio: "pipe"
+      stdio: "pipe",
+      cwd: startupDirectory
     });
 
     this.lineReader = readline.createInterface({


### PR DESCRIPTION
## Summary

Fixes the `renv` regression found after `v0.1.6`: inline R now starts in the document workspace folder, so `.Rprofile` is discoverable at R startup when users remove `--vanilla` from `rmdNotebooks.r.args`.

- Threads the workspace folder into inline `RSession` creation.
- Passes that folder as `cwd` to `spawn()` for the inline R process.
- Keeps the existing per-document session behavior and existing restart/dispose semantics.
- Tightens `npm run smoke:renv` so it depends on startup working directory instead of forcing `R_PROFILE_USER`.
- Bumps package metadata to `0.1.7`.

## Why

`v0.1.6` made R startup flags configurable, but inline execution still spawned R from VS Code's parent working directory. The later protocol-level `setwd()` happens after R startup, which is too late for `.Rprofile` and therefore too late for `renv` auto-activation.

The terminal runner already passed `cwd: workspaceFolder`, which is why terminal execution worked while inline execution did not.

## Validation

- `npm run compile`
- `npm run test:unit` - 32 passing
- `npm run test:vscode` - 17 passing
- `npm run smoke:renv` - passed; verifies `--vanilla` skips `renv` activation and `--slave` starts in the project folder and loads the project library
- `npm test` - passed when rerun outside the sandbox after the nested VS Code Electron host hit the documented macOS `SIGABRT` sandbox issue