### PR TITLE
fix: preserve chunk header options on save

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,18 +49,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<Inline
   const rExecutor = new RExecutor(context.extensionUri);
   const terminalRunner = new RTerminalRunner();
   executorRegistry.register(rExecutor);
-  const cellStatusBarProvider = new InlineChunksCellStatusBarProvider();
 
   const notebookRuntime = new InlineChunksNotebookRuntime(outputStore, executorRegistry, outputChannelController, terminalRunner);
+  const cellStatusBarProvider = new InlineChunksCellStatusBarProvider(notebookRuntime);
 
   context.subscriptions.push(
     outputChannelController,
     terminalRunner,
     vscode.workspace.registerNotebookSerializer(INLINE_CHUNKS_NOTEBOOK_TYPE, new InlineChunksNotebookSerializer(), {
-      transientOutputs: true,
-      transientCellMetadata: {
-        rmdNotebooks: true
-      }
+      transientOutputs: true
     }),
     vscode.notebooks.registerNotebookCellStatusBarItemProvider(INLINE_CHUNKS_NOTEBOOK_TYPE, cellStatusBarProvider),
     notebookRuntime,

--- a/src/notebook/cellStatusBarProvider.ts
+++ b/src/notebook/cellStatusBarProvider.ts
@@ -2,7 +2,13 @@ import * as vscode from "vscode";
 import { formatChunkHeaderBadge, formatChunkHeaderTooltip } from "./metadataDisplay";
 import { getInlineChunksMetadata, INLINE_CHUNKS_NOTEBOOK_TYPE } from "./notebookTypes";
 
+interface ChunkIdLookup {
+  getChunkIdForCell(documentUri: string, cellIndex: number): string | undefined;
+}
+
 export class InlineChunksCellStatusBarProvider implements vscode.NotebookCellStatusBarItemProvider {
+  constructor(private readonly chunkIdLookup: ChunkIdLookup) {}
+
   public provideCellStatusBarItems(
     cell: vscode.NotebookCell,
     _token: vscode.CancellationToken
@@ -16,6 +22,12 @@ export class InlineChunksCellStatusBarProvider implements vscode.NotebookCellSta
       return undefined;
     }
 
+    // chunkId can be undefined on the initial render before refreshNotebook
+    // populates the runtime snapshot. editChunkHeader's active-selection
+    // fallback handles it (status-bar clicks activate their cell). Don't fire
+    // a refresh here when the snapshot updates — that would re-introduce the
+    // dirty-on-open regression this PR fixed (#5).
+    const chunkId = this.chunkIdLookup.getChunkIdForCell(cell.notebook.uri.toString(), cell.index);
     const headerItem = new vscode.NotebookCellStatusBarItem(
       `$(code) ${formatChunkHeaderBadge(metadata)}`,
       vscode.NotebookCellStatusBarAlignment.Left
@@ -25,7 +37,7 @@ export class InlineChunksCellStatusBarProvider implements vscode.NotebookCellSta
     headerItem.command = {
       title: "Edit Chunk Header",
       command: "rmdNotebooks.editChunkHeader",
-      arguments: [cell.notebook.uri.toString(), metadata.chunkId]
+      arguments: [cell.notebook.uri.toString(), chunkId]
     };
 
     return headerItem;

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
-import { assignChunkIdentities } from "../document/chunkIdentity";
+import { assignChunkIdentities, createIdentitySeed } from "../document/chunkIdentity";
 import { ChunkIdentitySeed, ChunkOutputRecord, ExecutableChunk, OutputItem, ParsedExecutableChunk } from "../document/chunkTypes";
 import { OutputChannelController } from "../editor/outputChannelController";
 import { ExecutorRegistry } from "../execution/executorRegistry";
@@ -163,6 +163,11 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         execution.end(undefined, Date.now());
       }
     });
+  }
+
+  public getChunkIdForCell(documentUri: string, cellIndex: number): string | undefined {
+    const snapshot = this.snapshots.get(documentUri);
+    return snapshot?.chunks.find((entry) => entry.index === cellIndex)?.chunk.identity.chunkId;
   }
 
   public async getDocumentState(documentUri: string): Promise<{
@@ -487,13 +492,14 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
   private async refreshNotebook(notebook: vscode.NotebookDocument): Promise<NotebookSnapshot> {
     const outputs = await this.ensureOutputsLoaded(notebook.uri.toString());
-    let snapshot = buildNotebookSnapshot(notebook, outputs);
+    const previousSnapshot = this.snapshots.get(notebook.uri.toString());
+    let snapshot = buildNotebookSnapshot(notebook, outputs, previousSnapshot);
     this.snapshots.set(notebook.uri.toString(), snapshot);
     reconcileOutputs(snapshot, outputs);
     await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
     const metadataChanged = await this.applyChunkMetadata(notebook, snapshot);
     if (metadataChanged) {
-      snapshot = buildNotebookSnapshot(notebook, outputs);
+      snapshot = buildNotebookSnapshot(notebook, outputs, snapshot);
       this.snapshots.set(notebook.uri.toString(), snapshot);
       reconcileOutputs(snapshot, outputs);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
@@ -506,7 +512,8 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     for (const entry of snapshot.chunks) {
       const existing = getInlineChunksMetadata(entry.cell.metadata);
-      const nextMetadata = withInlineChunksMetadata(entry.cell.metadata, {
+
+      const targetSource: InlineChunksCodeCellMetadata = {
         kind: "code",
         header: existing?.kind === "code" ? existing.header : entry.chunk.header,
         headerInfo: existing?.kind === "code" ? existing.headerInfo : entry.chunk.headerInfo,
@@ -514,16 +521,15 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         label: entry.chunk.label,
         options: existing?.kind === "code" ? existing.options : parseChunkOptions(entry.chunk.headerInfo),
         fenceLength: existing?.kind === "code" ? existing.fenceLength : entry.chunk.fenceLength,
-        isClosed: true,
-        chunkId: entry.chunk.identity.chunkId,
-        contentHash: entry.chunk.identity.contentHash,
-        headerHash: entry.chunk.identity.headerHash,
-        bodyHash: entry.chunk.identity.bodyHash
-      } satisfies InlineChunksCodeCellMetadata);
+        isClosed: existing?.kind === "code" ? existing.isClosed : entry.chunk.isClosed
+      };
 
-      if (JSON.stringify(entry.cell.metadata) !== JSON.stringify(nextMetadata)) {
-        edits.push(vscode.NotebookEdit.updateCellMetadata(entry.index, nextMetadata));
+      if (existing && JSON.stringify(existing) === JSON.stringify(targetSource)) {
+        continue;
       }
+
+      const next = withInlineChunksMetadata(entry.cell.metadata, targetSource);
+      edits.push(vscode.NotebookEdit.updateCellMetadata(entry.index, next));
     }
 
     if (edits.length === 0) {
@@ -750,7 +756,11 @@ function buildPromptQuickPickItems(
 }
 
 
-function buildNotebookSnapshot(notebook: vscode.NotebookDocument, outputs: Map<string, ChunkOutputRecord>): NotebookSnapshot {
+function buildNotebookSnapshot(
+  notebook: vscode.NotebookDocument,
+  outputs: Map<string, ChunkOutputRecord>,
+  previousSnapshot?: NotebookSnapshot
+): NotebookSnapshot {
   const codeCells = notebook
     .getCells()
     .filter((cell) => cell.kind === vscode.NotebookCellKind.Code)
@@ -760,9 +770,9 @@ function buildNotebookSnapshot(notebook: vscode.NotebookDocument, outputs: Map<s
       parsed: toParsedChunk(notebook, cell)
     }));
 
-  const metadataSeeds = codeCells
-    .map(({ cell }) => toIdentitySeed(cell))
-    .filter((seed): seed is ChunkIdentitySeed => seed !== undefined);
+  const metadataSeeds = previousSnapshot
+    ? previousSnapshot.chunks.map((entry) => createIdentitySeed(entry.chunk))
+    : [];
 
   const outputSeeds = [...outputs.values()]
     .filter((record) => !metadataSeeds.some((seed) => seed.chunkId === record.chunkId))
@@ -833,24 +843,6 @@ function toParsedChunk(notebook: vscode.NotebookDocument, cell: vscode.NotebookC
       endLine,
       endCharacter: 3
     }
-  };
-}
-
-function toIdentitySeed(cell: vscode.NotebookCell): ChunkIdentitySeed | undefined {
-  const metadata = getInlineChunksMetadata(cell.metadata);
-  if (metadata?.kind !== "code" || !metadata.chunkId || !metadata.contentHash || !metadata.headerHash || !metadata.bodyHash) {
-    return undefined;
-  }
-
-  return {
-    chunkId: metadata.chunkId,
-    contentHash: metadata.contentHash,
-    headerHash: metadata.headerHash,
-    bodyHash: metadata.bodyHash,
-    language: metadata.language,
-    label: metadata.label,
-    startLine: cell.index * 2,
-    header: metadata.header
   };
 }
 

--- a/src/notebook/notebookSource.ts
+++ b/src/notebook/notebookSource.ts
@@ -86,6 +86,10 @@ function buildHeader(languageId: string, metadata: ReturnType<typeof getInlineCh
       return metadata.header;
     }
 
+    if (metadata.headerInfo && metadata.headerInfo.trim().length > 0) {
+      return `\`\`\`{${metadata.headerInfo}}`;
+    }
+
     return metadata.label ? `\`\`\`{${languageId} ${metadata.label}}` : `\`\`\`{${languageId}}`;
   }
 

--- a/src/notebook/notebookTypes.ts
+++ b/src/notebook/notebookTypes.ts
@@ -12,10 +12,6 @@ export interface InlineChunksCodeCellMetadata {
   options?: ChunkOptions;
   fenceLength: number;
   isClosed: boolean;
-  chunkId?: string;
-  contentHash?: string;
-  headerHash?: string;
-  bodyHash?: string;
 }
 
 export interface InlineChunksMarkupCellMetadata {

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -235,6 +235,84 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(savedSource.includes("```{r renamed, echo=FALSE, warning=FALSE}"));
   });
 
+  it("preserves chunk header options when saving after a body edit", async () => {
+    await writeFixture(
+      "preserve-options.qmd",
+      [
+        "# Preserve options",
+        "",
+        "```{r eval=FALSE}",
+        "print(\"should stay non-executable\")",
+        "```",
+        "",
+        "```{r labeled, echo=FALSE, warning=FALSE}",
+        "x <- 1",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("preserve-options.qmd");
+    const firstCodeCellIndex = findFirstCodeCellIndex(editor.notebook);
+    const firstCell = editor.notebook.cellAt(firstCodeCellIndex);
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(
+      firstCell.document.uri,
+      new vscode.Range(new vscode.Position(0, 0), firstCell.document.lineAt(0).range.end),
+      "print(\"edited body\")"
+    );
+    await vscode.workspace.applyEdit(edit);
+
+    await waitFor(() => (firstCell.document.getText().includes("edited body") ? true : undefined));
+
+    const saved = await editor.notebook.save();
+    assert.ok(saved, "Notebook save should succeed.");
+
+    const savedBytes = await vscode.workspace.fs.readFile(editor.notebook.uri);
+    const savedSource = Buffer.from(savedBytes).toString("utf8");
+
+    assert.ok(
+      savedSource.includes("```{r eval=FALSE}"),
+      `Expected unlabeled header to retain eval=FALSE; got:\n${savedSource}`
+    );
+    assert.ok(
+      savedSource.includes("```{r labeled, echo=FALSE, warning=FALSE}"),
+      `Expected labeled header to retain its options; got:\n${savedSource}`
+    );
+  });
+
+  it("does not mark the notebook dirty after opening an unedited file", async () => {
+    await writeFixture(
+      "clean-open.qmd",
+      [
+        "# Clean open",
+        "",
+        "```{r setup, include=FALSE}",
+        "x <- 1",
+        "```",
+        "",
+        "```{r labeled, echo=FALSE, warning=FALSE}",
+        "y <- 2",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("clean-open.qmd");
+
+    await waitForDocumentState(
+      editor.notebook.uri,
+      (state) => (state.snapshot?.chunkIds.length ?? 0) >= 2
+    );
+
+    assert.equal(
+      editor.notebook.isDirty,
+      false,
+      "Opening an unedited notebook should not mark it dirty."
+    );
+  });
+
   it("skips execution for eval=FALSE", async () => {
     await writeFixture(
       "eval-false.qmd",


### PR DESCRIPTION
## Summary

Fixes #5. Chunk header options like `eval=FALSE` and `fig.width` were getting silently dropped on save. The fix has two parts.

### Root cause

`src/extension.ts` registered the notebook serializer with `transientCellMetadata: { rmdNotebooks: true }`. With that flag set, VS Code strips the marked key from `NotebookData` before passing it to `serializeNotebook`, so the serializer never saw `cell.metadata.rmdNotebooks` and had no way to recover the original header. I confirmed this with diagnostic logging during the investigation: every `serialize.codeCell` event showed `metadataKeys: []` and `hasRmdNotebooks: false`.

Dropping the transient declaration lets VS Code keep `rmdNotebooks` through the serialize path, so the original header survives the round trip.

### Avoiding the dirty marker side effect

Removing `transientCellMetadata` would normally make the notebook open as dirty, because `applyChunkMetadata` writes identity fields (`chunkId`, `contentHash`, `headerHash`, `bodyHash`) on every refresh and any cell metadata write marks the document modified.

To avoid that, this PR moves identity entirely out of `cell.metadata`. Identity now lives in the runtime cache (`this.snapshots` on `InlineChunksNotebookRuntime`) and is reseeded across refreshes from the previous snapshot. The status bar provider asks the runtime for the current `chunkId` via a small `getChunkIdForCell` lookup. Cell metadata only carries the user facing parts (header, headerInfo, language, label, options, fenceLength, isClosed), and `applyChunkMetadata` only writes when those actually change, so a clean open does not push any cell metadata edits and the notebook stays clean.

### Defensive secondary fix

The fallback in `buildHeader()` (`src/notebook/notebookSource.ts`) used to emit just the language and label, dropping every other option whenever the fast path guard `metadata.language === languageId && metadata.header.trim().length > 0` failed. With the root cause fixed this fallback is rarely hit, but I would rather it preserve options than silently drop them (for example, if a cell language is changed before `applyChunkMetadata` re-syncs).

## Changes

- `src/extension.ts`: drop `transientCellMetadata.rmdNotebooks` from the serializer registration. Reorder so the runtime is constructed before the status bar provider, since the provider now consumes the runtime as a chunk id lookup.
- `src/notebook/notebookSource.ts`: in `buildHeader()`, fall back to `metadata.headerInfo` (raw header text minus the fence) before falling through to the bare language and label header.
- `src/notebook/notebookTypes.ts`: remove identity fields and helpers from the cell metadata shape. `InlineChunksCodeCellMetadata` no longer carries chunkId or hashes.
- `src/notebook/notebookRuntime.ts`: expose `getChunkIdForCell`, seed `assignChunkIdentities` from the previous snapshot via `createIdentitySeed`, and skip `applyChunkMetadata` writes when the resulting metadata is unchanged.
- `src/notebook/cellStatusBarProvider.ts`: query the runtime for the chunk id instead of reading it from cell metadata.
- `test/vscode/suite/extensionHost.test.ts`: regression test that opens a chunk with `eval=FALSE` plus a labeled chunk with multiple options, edits the body, saves, and checks that the on-disk header still has the options.

## Test plan

- [x] `npm run test:unit`: all 32 existing tests pass.
- [x] Manual verification with a packaged VSIX. Confirmed the bug (`metadataKeys: []` at serialize time) and confirmed the fix preserves `eval=FALSE` across:
  - edit body, Ctrl+S, close and reopen file
  - open, no edit, close (saving when prompted)
  - edit, save, close VS Code, reopen
- [x] Manual verification that opening an unedited `.Rmd` no longer leaves the tab marked dirty.
- [x] `npm run test:vscode`: the new test covers the edit+save case. I could not run the VS Code integration suite locally (the runner errored on VS Code 1.112.0 with Node 22, unrelated to these changes), and CI does not run `test:vscode` either, so this one needs a manual run on your machine.
