### PR TITLE
fix: preserve R session on inline timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- preserve chunk header options such as `eval=FALSE`, `fig.width`, `echo=FALSE`, and `warning=FALSE` when saving after body edits
+- keep notebooks clean on open by storing chunk identity in the runtime snapshot instead of writing it back to cell metadata
+- disable the inline interactive fallback timeout by default so legitimate slow chunks keep running
+- keep the inline R session alive when an opt-in timeout fires, while still allowing terminal fallback
+- wire the notebook Stop button to interrupt the active R execution without restarting the session
+- catch R interrupts in the inline session shim so interrupted chunks return a normal failed result and the session can continue
+
 ## 0.1.7
 
 - start inline R sessions in the document workspace folder so `.Rprofile` can activate project tools such as `renv`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Current limits:
 - static image plots only
 - no htmlwidgets
 - only a small subset of knitr options is enforced today: `eval=FALSE`, `include=FALSE`, `results='hide'`
-- unsupported interactive flows still fall back to an R terminal after timeout
+- unsupported interactive flows can fall back to an R terminal if you enable the timeout
 
 ## Commands
 
@@ -68,13 +68,15 @@ Current limits:
 
 The notebook toolbar also exposes `Restart R Session` and `View Source`.
 
-Common prompt-style interactions such as `menu()` and `readline()` are handled inline with VS Code pickers and input boxes. If execution still appears to stall because a chunk wants unsupported interactive input, the extension can prompt to run that chunk in an integrated R terminal instead. This is controlled by `rmdNotebooks.execution.interactiveFallbackBehavior` and `rmdNotebooks.execution.interactiveFallbackTimeoutMs`.
+Common prompt-style interactions such as `menu()` and `readline()` are handled inline with VS Code pickers and input boxes. The notebook Stop button interrupts the current inline R execution without restarting the session. If execution still appears to stall because a chunk wants unsupported interactive input, you can enable a timeout that prompts to run that chunk in an integrated R terminal instead. This is controlled by `rmdNotebooks.execution.interactiveFallbackBehavior` and `rmdNotebooks.execution.interactiveFallbackTimeoutMs`; the timeout is disabled by default with a value of `0`.
 
 ## Settings
 
 - `rmdNotebooks.r.path`: path to the R executable.
 - `rmdNotebooks.r.args`: arguments for inline chunk-execution R sessions. Defaults to `["--slave", "--vanilla"]`.
 - `rmdNotebooks.r.terminalArgs`: arguments for the interactive R terminal. Defaults to `["--vanilla"]`.
+- `rmdNotebooks.execution.interactiveFallbackTimeoutMs`: optional timeout for treating a stalled inline chunk as unsupported interactive input. Defaults to `0`, which disables the timeout.
+- `rmdNotebooks.execution.interactiveFallbackBehavior`: what to do when the optional interactive fallback timeout fires. Defaults to `prompt`.
 
 For projects that rely on startup files, such as `renv` projects that auto-activate from `.Rprofile`, remove `--vanilla` from the relevant setting. For example:
 

--- a/media/r/rmd_notebooks_session.R
+++ b/media/r/rmd_notebooks_session.R
@@ -264,6 +264,9 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
   }, error = function(error_condition) {
     success <<- FALSE
     message(conditionMessage(error_condition))
+  }, interrupt = function(interrupt_condition) {
+    success <<- FALSE
+    message("Execution interrupted.")
   })
 
   grDevices::dev.off()

--- a/package.json
+++ b/package.json
@@ -143,9 +143,9 @@
         },
         "rmdNotebooks.execution.interactiveFallbackTimeoutMs": {
           "type": "number",
-          "default": 15000,
-          "minimum": 1000,
-          "description": "How long inline execution can wait before assuming the chunk needs interactive terminal input."
+          "default": 0,
+          "minimum": 0,
+          "description": "How long inline execution can wait before assuming the chunk needs interactive terminal input. Set to 0 to disable the timeout."
         },
         "rmdNotebooks.execution.interactiveFallbackBehavior": {
           "type": "string",

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -34,6 +34,12 @@ interface RawExecutionPayload {
   plots: string[];
 }
 
+interface PendingExecution {
+  resolve: (payload: RawExecutionPayload) => void;
+  reject: (error: Error) => void;
+  abandoned: boolean;
+}
+
 export class RExecutor implements Executor {
   public readonly language = "r";
   private readonly sessions = new Map<string, RSession>();
@@ -52,25 +58,15 @@ export class RExecutor implements Executor {
 
   public async executeChunk(context: ExecutionContext): Promise<ExecutionResult> {
     const session = this.getOrCreateSession(context.documentUri, context.workspaceFolder);
-    const timeoutMs = vscode.workspace.getConfiguration("rmdNotebooks").get<number>("execution.interactiveFallbackTimeoutMs", 15000);
-    let payload: RawExecutionPayload;
-
-    try {
-      payload = await session.execute(
-        context.code,
-        context.workspaceFolder,
-        context.artifactDirectory,
-        context.plot,
-        timeoutMs,
-        context.prompt
-      );
-    } catch (error) {
-      if (error instanceof InteractiveExecutionError) {
-        this.sessions.delete(context.documentUri);
-        await session.dispose();
-      }
-      throw error;
-    }
+    const timeoutMs = vscode.workspace.getConfiguration("rmdNotebooks").get<number>("execution.interactiveFallbackTimeoutMs", 0);
+    const payload = await session.execute(
+      context.code,
+      context.workspaceFolder,
+      context.artifactDirectory,
+      context.plot,
+      timeoutMs,
+      context.prompt
+    );
 
     const items: OutputItem[] = [];
 
@@ -121,6 +117,11 @@ export class RExecutor implements Executor {
     await session.dispose();
   }
 
+  public async interruptSession(documentUri: string): Promise<void> {
+    const session = this.sessions.get(documentUri);
+    await session?.interrupt();
+  }
+
   public async disposeAll(): Promise<void> {
     await Promise.all([...this.sessions.keys()].map((uri) => this.disposeSession(uri)));
   }
@@ -147,10 +148,7 @@ class RSession {
   private readonly readyPromise: Promise<void>;
   private readyResolve!: () => void;
   private readyReject!: (error: Error) => void;
-  private pending: {
-    resolve: (payload: RawExecutionPayload) => void;
-    reject: (error: Error) => void;
-  } | undefined;
+  private pending: PendingExecution | undefined;
   private currentLines: string[] = [];
   private currentPromptLines: string[] = [];
   private waitingForResult = false;
@@ -241,7 +239,19 @@ class RSession {
     }
 
     return new Promise<RawExecutionPayload>((resolve, reject) => {
-      this.pending = { resolve, reject };
+      this.pending = {
+        abandoned: false,
+        resolve: (payload) => {
+          this.clearExecutionTimeout();
+          this.promptHandler = undefined;
+          resolve(payload);
+        },
+        reject: (error) => {
+          this.clearExecutionTimeout();
+          this.promptHandler = undefined;
+          reject(error);
+        }
+      };
       this.promptHandler = promptHandler;
       this.executionTimeoutMs = timeoutMs;
       this.runtimeStderr = "";
@@ -258,22 +268,15 @@ class RSession {
         this.process.stdin.write(`LINE:${encodeProtocolLine(line)}\n`);
       }
       this.process.stdin.write(`${COMMAND_END_MARKER}\n`);
-
-      const originalResolve = resolve;
-      const originalReject = reject;
-      this.pending = {
-        resolve: (payload) => {
-          this.clearExecutionTimeout();
-          this.promptHandler = undefined;
-          originalResolve(payload);
-        },
-        reject: (error) => {
-          this.clearExecutionTimeout();
-          this.promptHandler = undefined;
-          originalReject(error);
-        }
-      };
     });
+  }
+
+  public async interrupt(): Promise<void> {
+    if (!this.pending || this.pending.abandoned) {
+      return;
+    }
+
+    this.interruptProcess();
   }
 
   public async dispose(): Promise<void> {
@@ -315,18 +318,19 @@ class RSession {
       this.waitingForResult = false;
       const pending = this.pending;
       this.pending = undefined;
-      if (!pending) {
-        return;
-      }
 
       try {
+        if (!pending || pending.abandoned) {
+          return;
+        }
+
         const payload = parseRawExecutionPayload(this.currentLines);
         if (this.runtimeStderr.trim().length > 0) {
           payload.stderr = payload.stderr.length > 0 ? `${payload.stderr}\n${this.runtimeStderr.trimEnd()}` : this.runtimeStderr.trimEnd();
         }
         pending.resolve(payload);
       } catch (error) {
-        pending.reject(error instanceof Error ? error : new Error(String(error)));
+        pending?.reject(error instanceof Error ? error : new Error(String(error)));
       } finally {
         this.currentLines = [];
         this.runtimeStderr = "";
@@ -353,20 +357,19 @@ class RSession {
 
     this.executionTimeout = setTimeout(() => {
       const pending = this.pending;
-      if (!pending) {
+      if (!pending || pending.abandoned) {
         return;
       }
 
-      const hadPromptOpen = this.waitingForPrompt;
-      this.pending = undefined;
-      this.promptHandler = undefined;
-      this.waitingForResult = false;
-      this.waitingForPrompt = false;
-      this.currentLines = [];
-      this.currentPromptLines = [];
-      if (hadPromptOpen) {
-        this.writePromptResponse({ cancelled: true });
+      try {
+        this.interruptProcess();
+      } catch (error) {
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+        return;
       }
+
+      pending.abandoned = true;
+      this.promptHandler = undefined;
       pending.reject(
         new InteractiveExecutionError(
           `Inline execution timed out after ${this.executionTimeoutMs}ms and may need interactive input.`
@@ -379,6 +382,16 @@ class RSession {
     if (this.executionTimeout) {
       clearTimeout(this.executionTimeout);
       this.executionTimeout = undefined;
+    }
+  }
+
+  private interruptProcess(): void {
+    if (this.process.killed) {
+      return;
+    }
+
+    if (!this.process.kill("SIGINT")) {
+      throw new Error("Unable to interrupt R session.");
     }
   }
 

--- a/test/manual-workspace/interactive-timeout-smoke.qmd
+++ b/test/manual-workspace/interactive-timeout-smoke.qmd
@@ -1,0 +1,173 @@
+# Interactive Timeout Smoke Test
+
+Use this file manually with the Rmd Notebooks extension. Run chunks one at a time unless a section says otherwise.
+
+Suggested settings passes:
+
+1. Default behavior:
+
+```json
+{
+  "rmdNotebooks.execution.interactiveFallbackTimeoutMs": 0,
+  "rmdNotebooks.execution.interactiveFallbackBehavior": "prompt"
+}
+```
+
+2. Opt-in timeout fallback:
+
+```json
+{
+  "rmdNotebooks.execution.interactiveFallbackTimeoutMs": 3000,
+  "rmdNotebooks.execution.interactiveFallbackBehavior": "prompt"
+}
+```
+
+## Baseline State
+
+```{r baseline-state}
+smoke_state <- list()
+smoke_state$baseline <- TRUE
+x <- 42
+cat("baseline ok; x=", x, "\n", sep = "")
+```
+
+## Legitimate Slow Chunk
+
+With timeout disabled, this should finish after 5 seconds and keep the same R session.
+
+With a 3 second timeout enabled, this should produce the interactive fallback warning, but the session should not be killed.
+
+```{r legitimate-slow}
+smoke_state$slow_started <- TRUE
+Sys.sleep(5)
+smoke_state$slow_finished <- TRUE
+cat("slow chunk finished; x=", x, "\n", sep = "")
+```
+
+```{r check-after-slow}
+cat("x still exists: ", exists("x"), "\n", sep = "")
+cat("x=", x, "\n", sep = "")
+cat("slow_started=", isTRUE(smoke_state$slow_started), "\n", sep = "")
+cat("slow_finished=", isTRUE(smoke_state$slow_finished), "\n", sep = "")
+```
+
+## Supported Input Prompt
+
+This should show a VS Code input box. Type any value.
+
+```{r readline-supported}
+name <- readline("Package or project name? ")
+smoke_state$readline_value <- name
+cat("readline value=", name, "\n", sep = "")
+```
+
+## Supported Menu Prompt
+
+This should show a VS Code quick pick.
+
+```{r menu-supported}
+choice <- menu(c("alpha", "beta", "gamma"), title = "Pick a smoke option")
+smoke_state$menu_choice <- choice
+cat("menu choice=", choice, "\n", sep = "")
+```
+
+## Supported Yes/No Prompt
+
+This should show a VS Code quick pick with Yes and No.
+
+```{r ask-yes-no-supported}
+answer <- askYesNo("Keep testing inline prompts?", default = TRUE)
+smoke_state$ask_yes_no <- answer
+cat("askYesNo answer=", answer, "\n", sep = "")
+```
+
+## Prompt Cancellation
+
+Run these and press Escape or cancel the VS Code UI.
+
+Expected:
+
+- `readline()` returns an empty string.
+- `menu()` returns `0`.
+- `askYesNo(..., default = NA)` returns `NA`.
+
+```{r prompt-cancel-readline}
+cancelled_input <- readline("Cancel this input with Escape")
+cat("cancelled readline value length=", nchar(cancelled_input), "\n", sep = "")
+```
+
+```{r prompt-cancel-menu}
+cancelled_menu <- menu(c("one", "two"), title = "Cancel this menu")
+cat("cancelled menu value=", cancelled_menu, "\n", sep = "")
+```
+
+```{r prompt-cancel-askyesno}
+cancelled_confirm <- askYesNo("Cancel this confirmation", default = NA)
+cat("cancelled askYesNo is NA: ", is.na(cancelled_confirm), "\n", sep = "")
+```
+
+## Ordinary R Error
+
+This should fail the cell but keep the R session alive.
+
+```{r ordinary-error}
+smoke_state$error_started <- TRUE
+stop("intentional smoke-test error")
+```
+
+```{r check-after-error}
+cat("session survived ordinary error: ", exists("x") && identical(x, 42), "\n", sep = "")
+cat("error_started=", isTRUE(smoke_state$error_started), "\n", sep = "")
+```
+
+## Stop Button / SIGINT
+
+Start this chunk, then click the notebook Stop button before it completes.
+
+After it stops, run the next chunk. Expected: the session is still alive, `interrupt_started` is `TRUE`, and `interrupt_finished` is absent or `FALSE`.
+
+```{r interrupt-with-stop}
+smoke_state$interrupt_started <- TRUE
+for (i in seq_len(60)) {
+  cat("tick ", i, "\n", sep = "")
+  flush.console()
+  Sys.sleep(1)
+}
+smoke_state$interrupt_finished <- TRUE
+cat("interrupt chunk finished without stop\n")
+```
+
+```{r check-after-stop}
+cat("session survived stop: ", exists("x") && identical(x, 42), "\n", sep = "")
+cat("interrupt_started=", isTRUE(smoke_state$interrupt_started), "\n", sep = "")
+cat("interrupt_finished=", isTRUE(smoke_state$interrupt_finished), "\n", sep = "")
+```
+
+## Unsupported Raw Stdin
+
+This is the intentionally awkward case.
+
+With timeout disabled, it may block until you click Stop.
+
+With `interactiveFallbackTimeoutMs` set to `3000`, it should trigger fallback after about 3 seconds. If the behavior is `prompt`, choose whether to send it to the R terminal. The inline R session should still survive either way.
+
+```{r unsupported-scan}
+smoke_state$scan_started <- TRUE
+cat("scan() is about to read from raw stdin\n")
+value <- scan(file = "", what = character(), nmax = 1, quiet = TRUE)
+smoke_state$scan_value <- value
+cat("scan value=", paste(value, collapse = ","), "\n", sep = "")
+```
+
+```{r check-after-scan}
+cat("session survived scan path: ", exists("x") && identical(x, 42), "\n", sep = "")
+cat("scan_started=", isTRUE(smoke_state$scan_started), "\n", sep = "")
+cat("scan_value exists=", exists("smoke_state") && !is.null(smoke_state$scan_value), "\n", sep = "")
+```
+
+## Final State Summary
+
+```{r final-summary}
+cat("x=", x, "\n", sep = "")
+str(smoke_state)
+```

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -382,7 +382,9 @@ describe("Rmd Notebooks Notebook Host", () => {
     const targetCell = editor.notebook.cellAt(findFirstCodeCellIndex(editor.notebook));
     const edit = new vscode.WorkspaceEdit();
     edit.replace(targetCell.document.uri, new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 5)), "x + 3");
-    await vscode.workspace.applyEdit(edit);
+    const edited = await vscode.workspace.applyEdit(edit);
+    assert.ok(edited, "Cell body edit should be applied.");
+    await waitFor(() => (targetCell.document.getText().includes("x + 3") ? true : undefined));
 
     const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
       candidate.outputs.some((record) => record.stale)
@@ -481,6 +483,49 @@ describe("Rmd Notebooks Notebook Host", () => {
     );
 
     assert.ok(state.outputs.some((record) => record.outputTypes.includes("text")));
+  });
+
+  it("keeps the inline R session alive after an execution timeout", async () => {
+    await writeFixture(
+      "timeout-preserves-session.qmd",
+      [
+        "# Timeout preserves session",
+        "",
+        "```{r waiting}",
+        "x <- 42",
+        "Sys.sleep(2)",
+        "```",
+        "",
+        "```{r check}",
+        "cat(sprintf('x=%s\\n', x))",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 1000);
+    await updateTestSetting("execution.interactiveFallbackBehavior", "error");
+
+    const editor = await openNotebookEditor("timeout-preserves-session.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "error")
+    );
+
+    await sleep(1000);
+
+    editor.selection = singleCellRange(findLastCodeCellIndex(editor.notebook));
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "success" && record.outputTypes.includes("text"))
+    );
+
+    assert.ok(state.outputChannelText.includes("x=42"));
+    assert.equal(vscode.window.terminals.length, 0);
   });
 
   it("stops run-all after redirecting an interactive chunk to the R terminal", async () => {
@@ -657,7 +702,7 @@ async function writeFixture(name: string, contents: string): Promise<void> {
 }
 
 async function resetTestSettings(): Promise<void> {
-  await updateTestSetting("execution.interactiveFallbackTimeoutMs", 15000);
+  await updateTestSetting("execution.interactiveFallbackTimeoutMs", 0);
   await updateTestSetting("execution.interactiveFallbackBehavior", "prompt");
 }
 
@@ -738,4 +783,8 @@ async function waitFor<T>(producer: () => Promise<T | undefined> | T | undefined
   }
 
   throw new Error(`Timed out after ${timeoutMs}ms.`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary

Fixes inline execution timeouts killing the entire R session.

This PR changes inline timeout handling so legitimate slow chunks are not treated as interactive by default, and opt-in timeout fallback no longer disposes the R process. It also wires the notebook Stop button to interrupt the active R execution.

Fixes #6.

## Changes

- Default `rmdNotebooks.execution.interactiveFallbackTimeoutMs` to `0` to disable wall-clock fallback timeout.
- Add `RExecutor.interruptSession()` so the notebook Stop button sends `SIGINT` to the active R process.
- Stop disposing/deleting the R session when `InteractiveExecutionError` is raised.
- Catch R `interrupt` conditions in the session shim so interrupted chunks return a normal failed result and the command loop continues.
- Drain abandoned timeout results so late protocol output cannot attach to a later cell.
- Add regression coverage for preserving session state after timeout.
- Add a manual smoke QMD for prompt, timeout, Stop, error, and raw-stdin paths.
- Update README and changelog for the new behavior.