### PR TITLE
fix: restore chunk outputs to the right cell after a reload

### DIFF
--- a/src/document/chunkIdentity.ts
+++ b/src/document/chunkIdentity.ts
@@ -3,12 +3,19 @@ import { ChunkIdentitySeed, ExecutableChunk, ParsedExecutableChunk } from "./chu
 
 const POSITION_MATCH_WINDOW = 25;
 
+interface ChunkIdentityWork {
+  chunk: ParsedExecutableChunk;
+  bodyHash: string;
+  headerHash: string;
+  contentHash: string;
+  chunkId?: string;
+}
+
 export function assignChunkIdentities(
   documentUri: string,
   parsedChunks: ParsedExecutableChunk[],
   previousSeeds: ChunkIdentitySeed[] = []
 ): ExecutableChunk[] {
-  const previousPool = new Map(previousSeeds.map((seed) => [seed.chunkId, seed]));
   const usedPreviousIds = new Set<string>();
 
   const exactCandidates = new Map<string, ChunkIdentitySeed[]>();
@@ -23,33 +30,80 @@ export function assignChunkIdentities(
     pushCandidate(languageCandidates, seed.language, seed);
   }
 
-  return parsedChunks.map((chunk, index) => {
+  const work: ChunkIdentityWork[] = parsedChunks.map((chunk) => {
     const bodyHash = sha1(normalizeBody(chunk.body));
     const headerHash = sha1(normalizeHeader(chunk.header));
     const contentHash = sha1(`${headerHash}:${bodyHash}`);
-
-    const matchedSeed =
-      takeExactMatch(exactCandidates, contentHash, usedPreviousIds) ??
-      takeNearestMatch(labelCandidates.get(getLabelKey(chunk.language, chunk.label)), chunk.startLine, usedPreviousIds) ??
-      takeNearestMatch(languageCandidates.get(chunk.language), chunk.startLine, usedPreviousIds);
-
-    const chunkId =
-      matchedSeed?.chunkId ??
-      sha1(`${documentUri}:${chunk.language}:${chunk.label ?? ""}:${chunk.startLine}:${headerHash}`);
-
-    usedPreviousIds.add(chunkId);
-    previousPool.delete(chunkId);
-
-    return {
-      ...chunk,
-      identity: {
-        chunkId,
-        contentHash,
-        headerHash,
-        bodyHash
-      }
-    };
+    return { chunk, bodyHash, headerHash, contentHash };
   });
+
+  // Exact content matches are claimed across every chunk first, so a fuzzy
+  // (label/position) match on one chunk can never steal a seed that another
+  // chunk matches exactly.
+  for (const entry of work) {
+    const matched = takeExactMatch(exactCandidates, entry.contentHash, usedPreviousIds);
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    const matched = takeNearestMatch(
+      labelCandidates.get(getLabelKey(entry.chunk.language, entry.chunk.label)),
+      entry.chunk.startLine,
+      usedPreviousIds
+    );
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    const matched = takeNearestMatch(languageCandidates.get(entry.chunk.language), entry.chunk.startLine, usedPreviousIds);
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    entry.chunkId = generateUniqueChunkId(documentUri, entry, usedPreviousIds);
+    usedPreviousIds.add(entry.chunkId);
+  }
+
+  return work.map((entry) => ({
+    ...entry.chunk,
+    identity: {
+      chunkId: entry.chunkId as string,
+      contentHash: entry.contentHash,
+      headerHash: entry.headerHash,
+      bodyHash: entry.bodyHash
+    }
+  }));
+}
+
+function generateUniqueChunkId(documentUri: string, entry: ChunkIdentityWork, usedPreviousIds: Set<string>): string {
+  const base = `${documentUri}:${entry.chunk.language}:${entry.chunk.label ?? ""}:${entry.chunk.startLine}:${entry.headerHash}`;
+  let chunkId = sha1(base);
+  let salt = 0;
+  // The base id is derived from the chunk position/header, so it can collide
+  // with a previously generated id of the same shape. Salt until it is unique.
+  while (usedPreviousIds.has(chunkId)) {
+    salt += 1;
+    chunkId = sha1(`${base}:${salt}`);
+  }
+  return chunkId;
 }
 
 export function createIdentitySeed(chunk: ExecutableChunk): ChunkIdentitySeed {

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -79,7 +79,12 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       this.controller,
       vscode.workspace.onDidOpenNotebookDocument((notebook) => void this.handleNotebookOpened(notebook)),
       vscode.workspace.onDidChangeNotebookDocument((event) => void this.handleNotebookChanged(event)),
-      vscode.workspace.onDidCloseNotebookDocument((notebook) => void this.handleNotebookClosed(notebook))
+      vscode.workspace.onDidCloseNotebookDocument((notebook) => void this.handleNotebookClosed(notebook)),
+      vscode.window.onDidChangeActiveNotebookEditor((editor) => {
+        if (editor && isInlineChunksNotebook(editor.notebook)) {
+          void this.restoreOutputsToNotebook(editor.notebook);
+        }
+      })
     );
 
     for (const notebook of vscode.workspace.notebookDocuments) {
@@ -546,7 +551,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   private async restoreOutputsToNotebook(notebook: vscode.NotebookDocument): Promise<void> {
-    const snapshot = this.snapshots.get(notebook.uri.toString());
+    // On a window reload a notebook can become the active editor before its
+    // snapshot has been built (the active-editor event races with initialize),
+    // so build it on demand instead of bailing out and never restoring.
+    const snapshot = this.snapshots.get(notebook.uri.toString()) ?? (await this.refreshNotebook(notebook));
     if (!snapshot) {
       return;
     }
@@ -555,21 +563,36 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     if (outputs.size === 0) {
       return;
     }
+
+    const pending = snapshot.chunks.filter((entry) => {
+      const record = outputs.get(entry.chunk.identity.chunkId);
+      if (!record) {
+        return false;
+      }
+      return notebook.cellAt(entry.index).outputs.length === 0;
+    });
+    if (pending.length === 0) {
+      return;
+    }
+
     const selected = await this.ensureControllerSelected(notebook);
     if (!selected) {
       return;
     }
     await this.withOutputSync(notebook.uri.toString(), async () => {
-      for (const entry of snapshot.chunks) {
+      for (const entry of pending) {
         const record = outputs.get(entry.chunk.identity.chunkId);
         if (!record) {
           continue;
         }
 
         const execution = this.controller.createNotebookCellExecution(notebook.cellAt(entry.index));
-        execution.start(Date.now());
+        // Restoring previously captured output is not a real run, so omit the
+        // timestamps: passing capturedAt (in the past) as the end time made
+        // VS Code render a negative duration like "-50.-4s".
+        execution.start();
         await execution.replaceOutput(await createNotebookOutputs(record));
-        execution.end(record.status === "success", record.capturedAt ?? Date.now());
+        execution.end(record.status === "success");
       }
     });
   }

--- a/src/test/suite/chunkIdentity.test.ts
+++ b/src/test/suite/chunkIdentity.test.ts
@@ -81,4 +81,33 @@ describe("chunkIdentity", () => {
     assert.equal(byLabel.get("chunk-a"), initial[0].identity.chunkId);
     assert.equal(byLabel.get("chunk-b"), initial[1].identity.chunkId);
   });
+
+  it("does not let an empty chunk steal a neighbour's output after a reload", () => {
+    const source = ["```{r}", "print('output 1.1')", "```", "", "```{r}", "```", "", "```{r}", "print('output 1.2')", "```"].join("\n");
+    const initial = assignChunkIdentities("file:///doc.Rmd", parseExecutableChunks("file:///doc.Rmd", source));
+
+    // Only the two chunks that produced output get persisted; the empty chunk
+    // was never run, so it has no seed.
+    const seeds = [initial[0], initial[2]].map((chunk) => ({
+      chunkId: chunk.identity.chunkId,
+      contentHash: chunk.identity.contentHash,
+      headerHash: chunk.identity.headerHash,
+      bodyHash: chunk.identity.bodyHash,
+      language: chunk.language,
+      label: chunk.label,
+      startLine: chunk.startLine,
+      header: chunk.header
+    }));
+
+    const reloaded = assignChunkIdentities("file:///doc.Rmd", parseExecutableChunks("file:///doc.Rmd", source), seeds);
+
+    assert.equal(reloaded[0].identity.chunkId, initial[0].identity.chunkId);
+    assert.equal(reloaded[2].identity.chunkId, initial[2].identity.chunkId);
+    // The empty middle chunk must not inherit either neighbour's id.
+    assert.notEqual(reloaded[1].identity.chunkId, initial[0].identity.chunkId);
+    assert.notEqual(reloaded[1].identity.chunkId, initial[2].identity.chunkId);
+    // Every chunk keeps a distinct id, so no output is restored twice.
+    const ids = new Set(reloaded.map((chunk) => chunk.identity.chunkId));
+    assert.equal(ids.size, reloaded.length);
+  });
 });


### PR DESCRIPTION
## Summary

After a window reload, restored chunk outputs could land on the wrong cell and show up twice, render negative run durations, and a notebook that was the active editor on reload would stay blank until it was closed and reopened. This fixes the three issues, which share the reload restore path.

### Root cause: outputs restored to the wrong cell

On reload the notebook is re-parsed without cell metadata, so chunk identities have to be re-derived by matching each cell against the stored output records. `assignChunkIdentities` did this greedily, one chunk at a time, trying exact content hash, then label, then nearest-by-position. An unrun empty chunk (no record of its own) would fall through to the position fallback and grab a neighbour's record before that neighbour got to claim its own exact match. The real chunk then regenerated a "fresh" id from `documentUri:language:label:startLine:headerHash`, which is exactly the tuple its original id was derived from, so the fresh id collided with the stolen one. Both cells ended up with the same `chunkId` and the same output was restored to both.

The fix claims every exact content match across all chunks first, before any fuzzy fallback runs, so a fuzzy match can no longer take a seed that another chunk matches exactly. Fresh ids are also salted so they cannot collide with an id that has already been claimed in the same pass.

### Negative run durations

`restoreOutputsToNotebook` called `execution.start(Date.now())` but `execution.end(success, record.capturedAt)`, where `capturedAt` is when the chunk originally ran (in the past). VS Code subtracts the two and rendered durations like `-50.-4s`. Restoring captured output is not a real run, so the timestamps are now omitted.

### Active notebook stays blank until reopened

Restoring requires the controller to be selected, which only works for the active editor, so a notebook restores when it becomes active. `restoreOutputsToNotebook` bailed out when no snapshot existed yet, and on reload the active-editor event can fire before `initialize` has built that notebook's snapshot, so nothing restored and nothing retried. It now builds the snapshot on demand, and restore also runs on `onDidChangeActiveNotebookEditor`.

## Changes

- `src/document/chunkIdentity.ts`: `assignChunkIdentities` now matches in phases (all exact content matches, then label-nearest, then language-nearest) instead of greedily per chunk, and `generateUniqueChunkId` salts a generated id until it does not collide with an already-claimed id.
- `src/notebook/notebookRuntime.ts`: `restoreOutputsToNotebook` omits execution timestamps, builds the snapshot on demand when one is missing, and only restores cells whose output is currently empty; `initialize` also restores on `onDidChangeActiveNotebookEditor`.
- `src/test/suite/chunkIdentity.test.ts`: regression test that an empty chunk between two output-bearing chunks does not steal a neighbour's id after a reload, and that every chunk keeps a distinct id.

## Test plan

- [x] `npm run test:unit`: 33 tests pass (32 existing plus the new regression test).
- [x] `npm run test:vscode`: 22 integration tests pass.
- [x] Manual verification in the Extension Development Host with an `.Rmd` of three unlabeled chunks where the middle one is empty:
  - Run all chunks, Reload Window: each output is on its own cell, the empty cell stays empty, no duplicate, no negative duration.
  - Open a second notebook too, run both, leave the second one active, Reload Window: its output is restored on open instead of staying blank until reopened.
