### PR TITLE
feat: make the inline R session startup timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+- Add `rmdNotebooks.r.startupTimeoutMs` to configure the inline R session startup budget (default 10000ms), for projects with slow R startup (renv, heavy `.Rprofile`, Bioconductor).
 - attach inline R sessions to vscode-R so variables can appear in the R workspace viewer
 - run inline chunks in `.GlobalEnv` and honor project `.Rprofile` startup by default
 - add vscode-R as an extension dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0
 
-- Add `rmdNotebooks.r.startupTimeoutMs` to configure the inline R session startup budget (default 10000ms), for projects with slow R startup (renv, heavy `.Rprofile`, Bioconductor).
+- Add `rmdNotebooks.r.startupTimeoutMs` to configure the inline R session startup budget (default 30000ms), for projects with slow R startup (renv, heavy `.Rprofile`, Bioconductor). The startup timeout error now reports the budget and names the setting to raise.
 - Fix: an inline session that fails to start is no longer cached, so re-running a chunk retries from scratch instead of repeating the startup error.
 - attach inline R sessions to vscode-R so variables can appear in the R workspace viewer
 - run inline chunks in `.GlobalEnv` and honor project `.Rprofile` startup by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0
 
 - Add `rmdNotebooks.r.startupTimeoutMs` to configure the inline R session startup budget (default 10000ms), for projects with slow R startup (renv, heavy `.Rprofile`, Bioconductor).
+- Fix: an inline session that fails to start is no longer cached, so re-running a chunk retries from scratch instead of repeating the startup error.
 - attach inline R sessions to vscode-R so variables can appear in the R workspace viewer
 - run inline chunks in `.GlobalEnv` and honor project `.Rprofile` startup by default
 - add vscode-R as an extension dependency

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
         },
         "rmdNotebooks.r.startupTimeoutMs": {
           "type": "number",
-          "default": 10000,
+          "default": 30000,
           "minimum": 1000,
           "description": "How long to wait (in milliseconds) for an inline R session to finish starting before reporting a startup timeout. Increase this for projects with slow R startup, e.g. renv autoloading, a heavy .Rprofile, or Bioconductor."
         },

--- a/package.json
+++ b/package.json
@@ -148,6 +148,12 @@
           "default": true,
           "description": "Source ~/.vscode-R/init.R in inline R sessions when present. This can let vscode-R attach its session watcher to inline notebook sessions."
         },
+        "rmdNotebooks.r.startupTimeoutMs": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 1000,
+          "description": "How long to wait (in milliseconds) for an inline R session to finish starting before reporting a startup timeout. Increase this for projects with slow R startup, e.g. renv autoloading, a heavy .Rprofile, or Bioconductor."
+        },
         "rmdNotebooks.execution.interactiveFallbackTimeoutMs": {
           "type": "number",
           "default": 0,

--- a/src/document/chunkIdentity.ts
+++ b/src/document/chunkIdentity.ts
@@ -3,12 +3,19 @@ import { ChunkIdentitySeed, ExecutableChunk, ParsedExecutableChunk } from "./chu
 
 const POSITION_MATCH_WINDOW = 25;
 
+interface ChunkIdentityWork {
+  chunk: ParsedExecutableChunk;
+  bodyHash: string;
+  headerHash: string;
+  contentHash: string;
+  chunkId?: string;
+}
+
 export function assignChunkIdentities(
   documentUri: string,
   parsedChunks: ParsedExecutableChunk[],
   previousSeeds: ChunkIdentitySeed[] = []
 ): ExecutableChunk[] {
-  const previousPool = new Map(previousSeeds.map((seed) => [seed.chunkId, seed]));
   const usedPreviousIds = new Set<string>();
 
   const exactCandidates = new Map<string, ChunkIdentitySeed[]>();
@@ -23,33 +30,80 @@ export function assignChunkIdentities(
     pushCandidate(languageCandidates, seed.language, seed);
   }
 
-  return parsedChunks.map((chunk, index) => {
+  const work: ChunkIdentityWork[] = parsedChunks.map((chunk) => {
     const bodyHash = sha1(normalizeBody(chunk.body));
     const headerHash = sha1(normalizeHeader(chunk.header));
     const contentHash = sha1(`${headerHash}:${bodyHash}`);
-
-    const matchedSeed =
-      takeExactMatch(exactCandidates, contentHash, usedPreviousIds) ??
-      takeNearestMatch(labelCandidates.get(getLabelKey(chunk.language, chunk.label)), chunk.startLine, usedPreviousIds) ??
-      takeNearestMatch(languageCandidates.get(chunk.language), chunk.startLine, usedPreviousIds);
-
-    const chunkId =
-      matchedSeed?.chunkId ??
-      sha1(`${documentUri}:${chunk.language}:${chunk.label ?? ""}:${chunk.startLine}:${headerHash}`);
-
-    usedPreviousIds.add(chunkId);
-    previousPool.delete(chunkId);
-
-    return {
-      ...chunk,
-      identity: {
-        chunkId,
-        contentHash,
-        headerHash,
-        bodyHash
-      }
-    };
+    return { chunk, bodyHash, headerHash, contentHash };
   });
+
+  // Exact content matches are claimed across every chunk first, so a fuzzy
+  // (label/position) match on one chunk can never steal a seed that another
+  // chunk matches exactly.
+  for (const entry of work) {
+    const matched = takeExactMatch(exactCandidates, entry.contentHash, usedPreviousIds);
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    const matched = takeNearestMatch(
+      labelCandidates.get(getLabelKey(entry.chunk.language, entry.chunk.label)),
+      entry.chunk.startLine,
+      usedPreviousIds
+    );
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    const matched = takeNearestMatch(languageCandidates.get(entry.chunk.language), entry.chunk.startLine, usedPreviousIds);
+    if (matched) {
+      entry.chunkId = matched.chunkId;
+      usedPreviousIds.add(matched.chunkId);
+    }
+  }
+
+  for (const entry of work) {
+    if (entry.chunkId) {
+      continue;
+    }
+    entry.chunkId = generateUniqueChunkId(documentUri, entry, usedPreviousIds);
+    usedPreviousIds.add(entry.chunkId);
+  }
+
+  return work.map((entry) => ({
+    ...entry.chunk,
+    identity: {
+      chunkId: entry.chunkId as string,
+      contentHash: entry.contentHash,
+      headerHash: entry.headerHash,
+      bodyHash: entry.bodyHash
+    }
+  }));
+}
+
+function generateUniqueChunkId(documentUri: string, entry: ChunkIdentityWork, usedPreviousIds: Set<string>): string {
+  const base = `${documentUri}:${entry.chunk.language}:${entry.chunk.label ?? ""}:${entry.chunk.startLine}:${entry.headerHash}`;
+  let chunkId = sha1(base);
+  let salt = 0;
+  // The base id is derived from the chunk position/header, so it can collide
+  // with a previously generated id of the same shape. Salt until it is unique.
+  while (usedPreviousIds.has(chunkId)) {
+    salt += 1;
+    chunkId = sha1(`${base}:${salt}`);
+  }
+  return chunkId;
 }
 
 export function createIdentitySeed(chunk: ExecutableChunk): ChunkIdentitySeed {

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -136,7 +136,7 @@ export class RExecutor implements Executor {
     const rPath = configuration.get<string>("r.path", "R");
     const rArgs = getInlineRArgs(configuration);
     const sourceVscodeRSessionWatcher = configuration.get<boolean>("r.sourceVscodeRSessionWatcher", true);
-    const startupTimeoutMs = configuration.get<number>("r.startupTimeoutMs", 10000);
+    const startupTimeoutMs = configuration.get<number>("r.startupTimeoutMs", 30000);
     const sessionScriptPath = path.join(this.extensionUri.fsPath, "media", "r", "rmd_notebooks_session.R");
     const created = new RSession(rPath, rArgs, sessionScriptPath, workspaceFolder, sourceVscodeRSessionWatcher, startupTimeoutMs);
     this.sessions.set(documentUri, created);
@@ -177,7 +177,7 @@ class RSession {
     scriptPath: string,
     startupDirectory?: string,
     sourceVscodeRSessionWatcher = true,
-    startupTimeoutMs = 10000
+    startupTimeoutMs = 30000
   ) {
     this.process = spawn(rPath, rArgs, {
       stdio: "pipe",
@@ -198,7 +198,7 @@ class RSession {
     });
 
     this.startTimer = setTimeout(() => {
-      this.readyReject(new Error(`Timed out starting R session. ${this.startupErrors.join("\n")}`.trim()));
+      this.readyReject(new Error(`Timed out starting R session after ${startupTimeoutMs}ms. Increase rmdNotebooks.r.startupTimeoutMs if this project has a slow R startup. ${this.startupErrors.join("\n")}`.trim()));
     }, startupTimeoutMs);
 
     this.lineReader.on("line", (line) => this.handleStdoutLine(line));

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -136,8 +136,9 @@ export class RExecutor implements Executor {
     const rPath = configuration.get<string>("r.path", "R");
     const rArgs = getInlineRArgs(configuration);
     const sourceVscodeRSessionWatcher = configuration.get<boolean>("r.sourceVscodeRSessionWatcher", true);
+    const startupTimeoutMs = configuration.get<number>("r.startupTimeoutMs", 10000);
     const sessionScriptPath = path.join(this.extensionUri.fsPath, "media", "r", "rmd_notebooks_session.R");
-    const created = new RSession(rPath, rArgs, sessionScriptPath, workspaceFolder, sourceVscodeRSessionWatcher);
+    const created = new RSession(rPath, rArgs, sessionScriptPath, workspaceFolder, sourceVscodeRSessionWatcher, startupTimeoutMs);
     this.sessions.set(documentUri, created);
     return created;
   }
@@ -167,7 +168,8 @@ class RSession {
     rArgs: string[],
     scriptPath: string,
     startupDirectory?: string,
-    sourceVscodeRSessionWatcher = true
+    sourceVscodeRSessionWatcher = true,
+    startupTimeoutMs = 10000
   ) {
     this.process = spawn(rPath, rArgs, {
       stdio: "pipe",
@@ -189,7 +191,7 @@ class RSession {
 
     this.startTimer = setTimeout(() => {
       this.readyReject(new Error(`Timed out starting R session. ${this.startupErrors.join("\n")}`.trim()));
-    }, 10000);
+    }, startupTimeoutMs);
 
     this.lineReader.on("line", (line) => this.handleStdoutLine(line));
     this.process.stderr.on("data", (chunk) => {

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -140,6 +140,14 @@ export class RExecutor implements Executor {
     const sessionScriptPath = path.join(this.extensionUri.fsPath, "media", "r", "rmd_notebooks_session.R");
     const created = new RSession(rPath, rArgs, sessionScriptPath, workspaceFolder, sourceVscodeRSessionWatcher, startupTimeoutMs);
     this.sessions.set(documentUri, created);
+    // Evict a session that never becomes ready so the next run starts fresh
+    // instead of replaying the cached startup rejection.
+    created.ready().catch(() => {
+      if (this.sessions.get(documentUri) === created) {
+        this.sessions.delete(documentUri);
+      }
+      void created.dispose();
+    });
     return created;
   }
 }

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -79,7 +79,12 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       this.controller,
       vscode.workspace.onDidOpenNotebookDocument((notebook) => void this.handleNotebookOpened(notebook)),
       vscode.workspace.onDidChangeNotebookDocument((event) => void this.handleNotebookChanged(event)),
-      vscode.workspace.onDidCloseNotebookDocument((notebook) => void this.handleNotebookClosed(notebook))
+      vscode.workspace.onDidCloseNotebookDocument((notebook) => void this.handleNotebookClosed(notebook)),
+      vscode.window.onDidChangeActiveNotebookEditor((editor) => {
+        if (editor && isInlineChunksNotebook(editor.notebook)) {
+          void this.restoreOutputsToNotebook(editor.notebook);
+        }
+      })
     );
 
     for (const notebook of vscode.workspace.notebookDocuments) {
@@ -546,7 +551,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   private async restoreOutputsToNotebook(notebook: vscode.NotebookDocument): Promise<void> {
-    const snapshot = this.snapshots.get(notebook.uri.toString());
+    // On a window reload a notebook can become the active editor before its
+    // snapshot has been built (the active-editor event races with initialize),
+    // so build it on demand instead of bailing out and never restoring.
+    const snapshot = this.snapshots.get(notebook.uri.toString()) ?? (await this.refreshNotebook(notebook));
     if (!snapshot) {
       return;
     }
@@ -555,21 +563,36 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     if (outputs.size === 0) {
       return;
     }
+
+    const pending = snapshot.chunks.filter((entry) => {
+      const record = outputs.get(entry.chunk.identity.chunkId);
+      if (!record) {
+        return false;
+      }
+      return notebook.cellAt(entry.index).outputs.length === 0;
+    });
+    if (pending.length === 0) {
+      return;
+    }
+
     const selected = await this.ensureControllerSelected(notebook);
     if (!selected) {
       return;
     }
     await this.withOutputSync(notebook.uri.toString(), async () => {
-      for (const entry of snapshot.chunks) {
+      for (const entry of pending) {
         const record = outputs.get(entry.chunk.identity.chunkId);
         if (!record) {
           continue;
         }
 
         const execution = this.controller.createNotebookCellExecution(notebook.cellAt(entry.index));
-        execution.start(Date.now());
+        // Restoring previously captured output is not a real run, so omit the
+        // timestamps: passing capturedAt (in the past) as the end time made
+        // VS Code render a negative duration like "-50.-4s".
+        execution.start();
         await execution.replaceOutput(await createNotebookOutputs(record));
-        execution.end(record.status === "success", record.capturedAt ?? Date.now());
+        execution.end(record.status === "success");
       }
     });
   }

--- a/src/test/suite/chunkIdentity.test.ts
+++ b/src/test/suite/chunkIdentity.test.ts
@@ -81,4 +81,33 @@ describe("chunkIdentity", () => {
     assert.equal(byLabel.get("chunk-a"), initial[0].identity.chunkId);
     assert.equal(byLabel.get("chunk-b"), initial[1].identity.chunkId);
   });
+
+  it("does not let an empty chunk steal a neighbour's output after a reload", () => {
+    const source = ["```{r}", "print('output 1.1')", "```", "", "```{r}", "```", "", "```{r}", "print('output 1.2')", "```"].join("\n");
+    const initial = assignChunkIdentities("file:///doc.Rmd", parseExecutableChunks("file:///doc.Rmd", source));
+
+    // Only the two chunks that produced output get persisted; the empty chunk
+    // was never run, so it has no seed.
+    const seeds = [initial[0], initial[2]].map((chunk) => ({
+      chunkId: chunk.identity.chunkId,
+      contentHash: chunk.identity.contentHash,
+      headerHash: chunk.identity.headerHash,
+      bodyHash: chunk.identity.bodyHash,
+      language: chunk.language,
+      label: chunk.label,
+      startLine: chunk.startLine,
+      header: chunk.header
+    }));
+
+    const reloaded = assignChunkIdentities("file:///doc.Rmd", parseExecutableChunks("file:///doc.Rmd", source), seeds);
+
+    assert.equal(reloaded[0].identity.chunkId, initial[0].identity.chunkId);
+    assert.equal(reloaded[2].identity.chunkId, initial[2].identity.chunkId);
+    // The empty middle chunk must not inherit either neighbour's id.
+    assert.notEqual(reloaded[1].identity.chunkId, initial[0].identity.chunkId);
+    assert.notEqual(reloaded[1].identity.chunkId, initial[2].identity.chunkId);
+    // Every chunk keeps a distinct id, so no output is restored twice.
+    const ids = new Set(reloaded.map((chunk) => chunk.identity.chunkId));
+    assert.equal(ids.size, reloaded.length);
+  });
 });

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -643,6 +643,73 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.equal(vscode.window.terminals.length, 0);
   });
 
+  it("times out starting the inline R session when the startup budget is too low", async () => {
+    await writeFixture(".Rprofile", "Sys.sleep(3)\n");
+    await writeFixture(
+      "startup-timeout.qmd",
+      [
+        "# Startup timeout",
+        "",
+        "```{r probe}",
+        "1 + 1",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("r.startupTimeoutMs", 1000);
+
+    const editor = await openNotebookEditor("startup-timeout.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "error")
+    );
+
+    assert.ok(state.outputs.some((record) => record.status === "error"));
+    assert.match(state.outputChannelText, /Timed out starting R session/);
+  });
+
+  it("starts a fresh inline R session after a startup timeout instead of caching the failure", async () => {
+    await writeFixture(".Rprofile", "Sys.sleep(3)\n");
+    await writeFixture(
+      "startup-eviction.qmd",
+      [
+        "# Startup eviction",
+        "",
+        "```{r probe}",
+        "1 + 1",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("startup-eviction.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+
+    // First run: an undersized budget makes startup time out.
+    await updateTestSetting("r.startupTimeoutMs", 1000);
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "error")
+    );
+
+    // Raise the budget and re-run without "Restart R Session": the failed session
+    // must be evicted so a fresh one starts and succeeds.
+    await updateTestSetting("r.startupTimeoutMs", 30000);
+    await sleep(200);
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "success" && record.outputTypes.includes("text"))
+    );
+
+    assert.ok(state.outputs.some((record) => record.status === "success"));
+    assert.match(state.outputChannelText, /\[1\] 2/);
+  });
+
   it("stops run-all after redirecting an interactive chunk to the R terminal", async () => {
     await writeFixture(
       "interactive-run-all.qmd",
@@ -840,6 +907,7 @@ async function deleteWorkspaceFile(name: string): Promise<void> {
 async function resetTestSettings(): Promise<void> {
   await updateTestSetting("r.args", undefined);
   await updateTestSetting("r.sourceVscodeRSessionWatcher", false);
+  await updateTestSetting("r.startupTimeoutMs", undefined);
   await updateTestSetting("execution.interactiveFallbackTimeoutMs", 0);
   await updateTestSetting("execution.interactiveFallbackBehavior", "prompt");
 }


### PR DESCRIPTION
## Summary

> Stacked on #11 and branched off it. Until #11 merges into `main`, that PR's commit and its files (`src/document/chunkIdentity.ts`, `src/notebook/notebookRuntime.ts`) show up in this diff. Merge #11 first.

Two related fixes to inline R session startup. First, the hardcoded 10s startup timeout is now configurable through a new `rmdNotebooks.r.startupTimeoutMs` setting, and its default is raised from 10000ms to 30000ms so renv/Bioconductor projects (the case this setting exists for) start cleanly out of the box; on timeout the error reports the budget and names the setting to raise. Second, an inline session that fails to become ready is no longer kept in the session cache, so re-running a chunk retries from scratch instead of replaying the original startup error.

The two changes are independent commits; the eviction fix can be split into its own PR if you prefer single-topic PRs. The 30000ms default and the more helpful timeout message were added per review (see thread).

### Root cause

`RSession` in `src/execution/rExecutor.ts` arms a hardcoded 10000ms timer that rejects with "Timed out starting R session" unless the session script prints `RMD_NOTEBOOKS_READY` first. In renv + Bioconductor projects, R startup is dominated by renv's autoloader, which makes blocking network calls at load time (online Bioconductor version validation and the PPM status check). Measured in such a project on the reporter's machine: time-to-READY was 5–18s and highly variable, with only ~0.3s of CPU time (rest is network wait; CRAN alone responded in ~11s). That intermittently crosses the 10s budget and produces the timeout, with no setting to adjust it.

Second issue found while investigating: a session that fails to become ready stays in the `sessions` map (only `disposeSession` removes it). `getOrCreateSession` then keeps returning the dead session, and every run re-awaits the already-rejected `readyPromise`, replaying the same error until a manual "Restart R Session", even after the underlying cause is gone.

## Changes

- `package.json`: add the `rmdNotebooks.r.startupTimeoutMs` configuration property (number, default 30000, minimum 1000).
- `src/execution/rExecutor.ts`:
  - `RSession` constructor takes a new `startupTimeoutMs` parameter (default 30000) and uses it for the startup `setTimeout` instead of the literal `10000`; on timeout the rejection message now reports the budget (`after ${startupTimeoutMs}ms`) and names `rmdNotebooks.r.startupTimeoutMs` so the user can fix it.
  - `getOrCreateSession` reads `r.startupTimeoutMs` from configuration and passes it to the `RSession` constructor.
  - `getOrCreateSession` attaches `created.ready().catch(...)` that removes the session from the `sessions` map (guarded by an identity check so it never evicts a newer session) and disposes it when startup fails, so the next call builds a fresh session.
- `test/vscode/suite/extensionHost.test.ts`: two integration tests, one asserting an undersized budget reports the startup timeout, one asserting a re-run after a timeout starts a fresh session and succeeds; `resetTestSettings` now clears `r.startupTimeoutMs` between tests.
- `CHANGELOG.md`: two entries under the 0.3.0 section.

## Test plan

- [x] `npm run test:unit`: 33 tests pass (unchanged).
- [x] `npm run test:vscode`: 24 tests pass, including the 2 new ones ("times out starting the inline R session when the startup budget is too low", "starts a fresh inline R session after a startup timeout instead of caching the failure").
- [x] The other 22 integration tests, which use the default budget (now 30000ms), still pass.
- [x] Manual verification in the Extension Development Host (see below): fail-fast at 1.0s with the timeout message, then success at ~3.4s after raising the budget to 30000, with no manual "Restart R Session".

### Minimal reproduction

Throwaway workspace, outside the repo:

- `/tmp/rmd-startup-test/.Rprofile` with `Sys.sleep(3)` (mimics slow renv/Bioconductor startup).
- `/tmp/rmd-startup-test/.vscode/settings.json` with `{ "rmdNotebooks.r.startupTimeoutMs": 1000 }`.
- `/tmp/rmd-startup-test/startup-test.Rmd` with one `r` chunk: `Sys.getpid(); 1 + 1`.

Steps: F5 ("Run Rmd Notebooks Extension") → File > Open Folder `/tmp/rmd-startup-test` → run the chunk.

- Before: the cell fails at ~1.0s with "Timed out starting R session" (1000ms budget < ~3s startup).
- After raising the setting to `30000`, save, and re-run the same cell without "Restart R Session": a fresh session starts and the cell returns `[1] 2` at ~3.4s. On the old code the dead session stayed cached and kept replaying the timeout.

