### PR TITLE
feat: queue inline R chunks so cells wait their turn, with interrupt

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,12 @@
         "title": "Rmd Notebooks: Run All Chunks"
       },
       {
+        "command": "rmdNotebooks.interruptSession",
+        "title": "Stop All Running Chunks",
+        "category": "Rmd Notebooks",
+        "icon": "$(stop-circle)"
+      },
+      {
         "command": "rmdNotebooks.clearCurrentOutput",
         "title": "Rmd Notebooks: Clear Current Output"
       },
@@ -103,6 +109,11 @@
     ],
     "menus": {
       "notebook/toolbar": [
+        {
+          "command": "rmdNotebooks.interruptSession",
+          "when": "notebookType == rmd-notebooks-vscode-notebook",
+          "group": "navigation@97"
+        },
         {
           "command": "rmdNotebooks.restartSession",
           "when": "notebookType == rmd-notebooks-vscode-notebook",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -11,6 +11,9 @@ export function registerCommands(controller: InlineChunksNotebookRuntime): vscod
     vscode.commands.registerCommand("rmdNotebooks.runAllChunks", async (documentUri?: string) => {
       await controller.runAllChunks(documentUri);
     }),
+    vscode.commands.registerCommand("rmdNotebooks.interruptSession", async (documentUri?: string) => {
+      await controller.interruptSession(documentUri);
+    }),
     vscode.commands.registerCommand("rmdNotebooks.clearCurrentOutput", async (documentUri?: string, chunkId?: string) => {
       await controller.clearCurrentOutput(documentUri, chunkId);
     }),

--- a/src/document/chunkTypes.ts
+++ b/src/document/chunkTypes.ts
@@ -80,7 +80,7 @@ export type OutputItem =
   | ImageOutputItem
   | HtmlOutputItem;
 
-export type ChunkOutputStatus = "running" | "success" | "error" | "redirected";
+export type ChunkOutputStatus = "running" | "success" | "error" | "redirected" | "cancelled";
 
 export interface ChunkOutputRecord {
   documentUri: string;

--- a/src/editor/editorController.ts
+++ b/src/editor/editorController.ts
@@ -5,6 +5,7 @@ import { ChunkDocumentSnapshot, ChunkOutputRecord, ExecutableChunk } from "../do
 import { OutputDecorationController } from "./outputDecorationController";
 import { ExecutorRegistry } from "../execution/executorRegistry";
 import { ExecutionResult } from "../execution/executorTypes";
+import { CancelledExecutionError } from "../execution/executionErrors";
 import { OutputStore } from "../persistence/outputStore";
 import { isSupportedDocument } from "../util/documentMatchers";
 import { ChunkCodeLensProvider } from "./chunkCodeLensProvider";
@@ -200,16 +201,14 @@ export class EditorController implements vscode.Disposable {
       outputs.set(chunk.identity.chunkId, record);
       this.outputChannelController.logRunCompleted(document, chunk, record);
     } catch (error) {
-      const record = createRecord(
-        chunk,
-        "error",
-        [
-          {
-            type: "error",
-            text: error instanceof Error ? error.message : String(error)
-          }
-        ]
-      );
+      const record = error instanceof CancelledExecutionError
+        ? createRecord(chunk, "cancelled", [])
+        : createRecord(chunk, "error", [
+            {
+              type: "error",
+              text: error instanceof Error ? error.message : String(error)
+            }
+          ]);
       outputs.set(
         chunk.identity.chunkId,
         record

--- a/src/editor/outputChannelController.ts
+++ b/src/editor/outputChannelController.ts
@@ -34,6 +34,8 @@ export class OutputChannelController implements vscode.Disposable {
       void vscode.window.showErrorMessage(`Rmd Notebooks: ${getChunkDisplayName(chunk)} failed. See the Rmd Notebooks output panel.`);
     } else if (record.status === "redirected") {
       void vscode.window.setStatusBarMessage(`Rmd Notebooks: redirected ${getChunkDisplayName(chunk)} to the R terminal`, 3000);
+    } else if (record.status === "cancelled") {
+      void vscode.window.setStatusBarMessage(`Rmd Notebooks: cancelled ${getChunkDisplayName(chunk)}`, 2500);
     } else {
       void vscode.window.setStatusBarMessage(`Rmd Notebooks: finished ${getChunkDisplayName(chunk)}`, 2500);
     }

--- a/src/editor/outputPreview.ts
+++ b/src/editor/outputPreview.ts
@@ -93,6 +93,10 @@ function getStateLabel(record: ChunkOutputRecord): string | undefined {
     return "[redirected]";
   }
 
+  if (record.status === "cancelled") {
+    return "[cancelled]";
+  }
+
   if (record.stale) {
     return "[stale]";
   }

--- a/src/execution/executionErrors.ts
+++ b/src/execution/executionErrors.ts
@@ -4,3 +4,10 @@ export class InteractiveExecutionError extends Error {
     this.name = "InteractiveExecutionError";
   }
 }
+
+export class CancelledExecutionError extends Error {
+  public constructor(message = "Execution cancelled before it started.") {
+    super(message);
+    this.name = "CancelledExecutionError";
+  }
+}

--- a/src/execution/executorTypes.ts
+++ b/src/execution/executorTypes.ts
@@ -29,6 +29,13 @@ export interface InteractivePromptResponse {
   value?: string;
 }
 
+// Structural subset of vscode.CancellationToken so executor types stay free of a
+// direct vscode dependency. A vscode.CancellationToken is assignable to this.
+export interface ExecutionCancellationToken {
+  readonly isCancellationRequested: boolean;
+  onCancellationRequested(listener: () => void): unknown;
+}
+
 export interface ExecutionContext {
   documentUri: string;
   workspaceFolder?: string;
@@ -39,6 +46,12 @@ export interface ExecutionContext {
   artifactDirectory?: string;
   plot?: PlotRenderOptions;
   prompt?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>;
+  // Invoked when the chunk leaves the queue and actually begins running in the R
+  // session, so the caller can flip the cell from "queued" to "running" only then.
+  onStart?: () => void;
+  // Cancels just this chunk: if it is still queued it is dropped from the queue; if
+  // it is the one currently running it is interrupted. Other chunks are unaffected.
+  token?: ExecutionCancellationToken;
 }
 
 export interface ExecutionResult {

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -5,13 +5,14 @@ import * as vscode from "vscode";
 import { ErrorOutputItem, HtmlOutputItem, ImageOutputItem, OutputItem, TextOutputItem } from "../document/chunkTypes";
 import {
   Executor,
+  ExecutionCancellationToken,
   ExecutionContext,
   ExecutionResult,
   InteractivePromptChoice,
   InteractivePromptRequest,
   InteractivePromptResponse
 } from "./executorTypes";
-import { InteractiveExecutionError } from "./executionErrors";
+import { CancelledExecutionError, InteractiveExecutionError } from "./executionErrors";
 import { getInlineRArgs } from "./rStartupArgs";
 
 const READY_MARKER = "RMD_NOTEBOOKS_READY";
@@ -40,6 +41,22 @@ interface PendingExecution {
   abandoned: boolean;
 }
 
+interface ExecutionRequest {
+  code: string;
+  workingDirectory?: string;
+  artifactDirectory?: string;
+  plot?: ExecutionContext["plot"];
+  timeoutMs: number;
+  promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>;
+  onStart?: () => void;
+}
+
+interface QueuedExecution {
+  readonly request: ExecutionRequest;
+  resolve: (payload: RawExecutionPayload) => void;
+  reject: (error: Error) => void;
+}
+
 export class RExecutor implements Executor {
   public readonly language = "r";
   private readonly sessions = new Map<string, RSession>();
@@ -65,7 +82,9 @@ export class RExecutor implements Executor {
       context.artifactDirectory,
       context.plot,
       timeoutMs,
-      context.prompt
+      context.prompt,
+      context.onStart,
+      context.token
     );
 
     const items: OutputItem[] = [];
@@ -119,7 +138,7 @@ export class RExecutor implements Executor {
 
   public async interruptSession(documentUri: string): Promise<void> {
     const session = this.sessions.get(documentUri);
-    await session?.interrupt();
+    session?.interrupt();
   }
 
   public async disposeAll(): Promise<void> {
@@ -159,6 +178,9 @@ class RSession {
   private readyResolve!: () => void;
   private readyReject!: (error: Error) => void;
   private pending: PendingExecution | undefined;
+  private pendingTask: QueuedExecution | undefined;
+  private readonly queue: QueuedExecution[] = [];
+  private starting = false;
   private currentLines: string[] = [];
   private currentPromptLines: string[] = [];
   private waitingForResult = false;
@@ -169,6 +191,7 @@ class RSession {
   private executionTimeout: NodeJS.Timeout | undefined;
   private executionTimeoutMs = 0;
   private sessionReady = false;
+  private alive = true;
   private runtimeStderr = "";
 
   public constructor(
@@ -219,23 +242,29 @@ class RSession {
       }
     });
     this.process.on("error", (error) => {
+      this.alive = false;
       this.readyReject(error);
       if (this.pending) {
         this.clearExecutionTimeout();
         this.promptHandler = undefined;
         this.pending.reject(error);
         this.pending = undefined;
+        this.pendingTask = undefined;
       }
+      this.failQueue(error);
     });
     this.process.on("exit", (code, signal) => {
+      this.alive = false;
       const message = `R session exited unexpectedly (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
       if (this.pending) {
         this.clearExecutionTimeout();
         this.promptHandler = undefined;
         this.pending.reject(new Error(message));
         this.pending = undefined;
+        this.pendingTask = undefined;
       }
       this.readyReject(new Error(message));
+      this.failQueue(new Error(message));
     });
 
     // Start an interactive R session, then source the command loop script over stdin.
@@ -246,61 +275,148 @@ class RSession {
     await this.readyPromise;
   }
 
-  public async execute(
+  public execute(
     code: string,
     workingDirectory?: string,
     artifactDirectory?: string,
     plot?: ExecutionContext["plot"],
     timeoutMs = 15000,
-    promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>
+    promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>,
+    onStart?: () => void,
+    token?: ExecutionCancellationToken
   ): Promise<RawExecutionPayload> {
-    await this.ready();
-    if (this.pending) {
-      throw new Error("R session is already executing a chunk.");
-    }
-
+    // Chunks are queued instead of rejected: a chunk requested while another is
+    // running waits its turn and runs in order, like cells in a Jupyter notebook.
     return new Promise<RawExecutionPayload>((resolve, reject) => {
-      this.pending = {
-        abandoned: false,
-        resolve: (payload) => {
-          this.clearExecutionTimeout();
-          this.promptHandler = undefined;
-          resolve(payload);
-        },
-        reject: (error) => {
-          this.clearExecutionTimeout();
-          this.promptHandler = undefined;
-          reject(error);
-        }
+      const task: QueuedExecution = {
+        request: { code, workingDirectory, artifactDirectory, plot, timeoutMs, promptHandler, onStart },
+        resolve,
+        reject
       };
-      this.promptHandler = promptHandler;
-      this.executionTimeoutMs = timeoutMs;
-      this.runtimeStderr = "";
-      this.armExecutionTimeout();
-      this.process.stdin.write(`${COMMAND_MARKER}\n`);
-      this.process.stdin.write(`WORKDIR:${encodeProtocolLine(workingDirectory ?? "")}\n`);
-      this.process.stdin.write(`ARTIFACT_DIR:${encodeProtocolLine(artifactDirectory ?? "")}\n`);
-      this.process.stdin.write(`PLOT_WIDTH:${plot?.widthInches ?? ""}\n`);
-      this.process.stdin.write(`PLOT_HEIGHT:${plot?.heightInches ?? ""}\n`);
-      this.process.stdin.write(`PLOT_DPI:${plot?.dpi ?? ""}\n`);
-      const codeLines = toProtocolLines(code);
-      this.process.stdin.write(`CODE_COUNT:${codeLines.length}\n`);
-      for (const line of codeLines) {
-        this.process.stdin.write(`LINE:${encodeProtocolLine(line)}\n`);
+      this.queue.push(task);
+      // Cancelling one cell affects only that cell: if it is still queued it is
+      // dropped; if it is the one running it is interrupted. The rest keep going.
+      if (token) {
+        if (token.isCancellationRequested) {
+          this.cancelTask(task);
+        } else {
+          token.onCancellationRequested(() => this.cancelTask(task));
+        }
       }
-      this.process.stdin.write(`${COMMAND_END_MARKER}\n`);
+      this.drainQueue();
     });
   }
 
-  public async interrupt(): Promise<void> {
-    if (!this.pending || this.pending.abandoned) {
+  // Cancels a single chunk without disturbing the others.
+  private cancelTask(task: QueuedExecution): void {
+    const queueIndex = this.queue.indexOf(task);
+    if (queueIndex >= 0) {
+      this.queue.splice(queueIndex, 1);
+      task.reject(new CancelledExecutionError());
       return;
     }
 
-    this.interruptProcess();
+    // Not queued anymore: only interrupt if it is the chunk currently running.
+    if (this.pendingTask === task && this.pending && !this.pending.abandoned) {
+      this.interruptProcess();
+    }
+  }
+
+  public interrupt(): void {
+    // A single interrupt stops the whole run: drop everything still queued, then
+    // interrupt the chunk currently executing (if any). A chunk already abandoned
+    // by an execution timeout was interrupted there, so it is left alone.
+    this.failQueue(new CancelledExecutionError());
+    if (this.pending && !this.pending.abandoned) {
+      this.interruptProcess();
+    }
+  }
+
+  // Starts the next queued chunk once the session is idle. Only one chunk runs
+  // at a time; the rest wait their turn instead of erroring out.
+  private drainQueue(): void {
+    if (this.pending || this.starting || this.queue.length === 0) {
+      return;
+    }
+    if (!this.alive) {
+      this.failQueue(new Error("R session is no longer running."));
+      return;
+    }
+
+    this.starting = true;
+    this.ready().then(
+      () => {
+        this.starting = false;
+        if (!this.alive) {
+          this.failQueue(new Error("R session is no longer running."));
+          return;
+        }
+        // interrupt() can empty the queue while we awaited readiness.
+        const task = this.queue.shift();
+        if (task) {
+          this.beginExecution(task);
+        }
+      },
+      (error) => {
+        this.starting = false;
+        this.failQueue(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
+  }
+
+  private beginExecution(task: QueuedExecution): void {
+    const { request } = task;
+    this.pendingTask = task;
+    this.pending = {
+      abandoned: false,
+      resolve: (payload) => {
+        this.clearExecutionTimeout();
+        this.promptHandler = undefined;
+        task.resolve(payload);
+      },
+      reject: (error) => {
+        this.clearExecutionTimeout();
+        this.promptHandler = undefined;
+        task.reject(error);
+      }
+    };
+    this.promptHandler = request.promptHandler;
+    this.executionTimeoutMs = request.timeoutMs;
+    this.runtimeStderr = "";
+    // The chunk is leaving the queue now, so let the caller mark the cell as
+    // running (rather than queued) starting from this moment.
+    request.onStart?.();
+    this.armExecutionTimeout();
+    this.process.stdin.write(`${COMMAND_MARKER}\n`);
+    this.process.stdin.write(`WORKDIR:${encodeProtocolLine(request.workingDirectory ?? "")}\n`);
+    this.process.stdin.write(`ARTIFACT_DIR:${encodeProtocolLine(request.artifactDirectory ?? "")}\n`);
+    this.process.stdin.write(`PLOT_WIDTH:${request.plot?.widthInches ?? ""}\n`);
+    this.process.stdin.write(`PLOT_HEIGHT:${request.plot?.heightInches ?? ""}\n`);
+    this.process.stdin.write(`PLOT_DPI:${request.plot?.dpi ?? ""}\n`);
+    const codeLines = toProtocolLines(request.code);
+    this.process.stdin.write(`CODE_COUNT:${codeLines.length}\n`);
+    for (const line of codeLines) {
+      this.process.stdin.write(`LINE:${encodeProtocolLine(line)}\n`);
+    }
+    this.process.stdin.write(`${COMMAND_END_MARKER}\n`);
+  }
+
+  private failQueue(error: Error): void {
+    const queued = this.queue.splice(0, this.queue.length);
+    for (const task of queued) {
+      task.reject(error);
+    }
   }
 
   public async dispose(): Promise<void> {
+    this.alive = false;
+    // Only a session that actually started gets its queued chunks cancelled here.
+    // A session disposed because startup failed (e.g. the eviction in
+    // getOrCreateSession) must let drainQueue reject the queue with the real
+    // startup error instead of masking it with a cancellation.
+    if (this.sessionReady) {
+      this.failQueue(new CancelledExecutionError("R session was disposed."));
+    }
     this.lineReader.close();
     this.process.stdin.end();
     this.process.kill();
@@ -339,6 +455,7 @@ class RSession {
       this.waitingForResult = false;
       const pending = this.pending;
       this.pending = undefined;
+      this.pendingTask = undefined;
 
       try {
         if (!pending || pending.abandoned) {
@@ -355,6 +472,8 @@ class RSession {
       } finally {
         this.currentLines = [];
         this.runtimeStderr = "";
+        // The slot is free again: kick off the next queued chunk, if any.
+        this.drainQueue();
       }
 
       return;
@@ -407,7 +526,12 @@ class RSession {
   }
 
   private interruptProcess(): void {
-    if (this.process.killed) {
+    // Guard on whether the process is still running, not on process.killed:
+    // child.killed flips to true after the first kill() and stays true even though
+    // the R session survives a SIGINT (it catches the interrupt). Keying off it would
+    // make every interrupt after the first one a no-op, so the currently running chunk
+    // could never be stopped again.
+    if (!this.alive) {
       return;
     }
 

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -11,7 +11,7 @@ import {
   InteractivePromptResponse,
   PlotRenderOptions
 } from "../execution/executorTypes";
-import { InteractiveExecutionError } from "../execution/executionErrors";
+import { CancelledExecutionError, InteractiveExecutionError } from "../execution/executionErrors";
 import { RTerminalRunner } from "../execution/rTerminalRunner";
 import { OutputStore } from "../persistence/outputStore";
 import {
@@ -45,6 +45,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
   private readonly metadataSyncInFlight = new Set<string>();
   private readonly outputSyncInFlight = new Set<string>();
+  private readonly executionAdmissions = new Map<string, Promise<void>>();
+  // Notebooks whose in-flight Run All / multi-cell run should stop before the next
+  // cell. Set by interruptSession ("Stop All"), checked between cells in the run loops.
+  private readonly runsToAbort = new Set<string>();
   private testPromptResponses: InteractivePromptResponse[] = [];
   private readonly testPromptRequests: InteractivePromptRequest[] = [];
   private executionOrder = 0;
@@ -64,14 +68,20 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     this.controller.supportedLanguages = ["r"];
     this.controller.supportsExecutionOrder = true;
     this.controller.executeHandler = async (cells, notebook) => {
+      const documentUri = notebook.uri.toString();
+      this.runsToAbort.delete(documentUri);
       for (const cell of cells) {
+        if (this.runsToAbort.has(documentUri)) {
+          break;
+        }
         await this.executeCell(notebook, cell);
       }
+      this.runsToAbort.delete(documentUri);
     };
-    this.controller.interruptHandler = async (notebook) => {
-      const executor = this.executorRegistry.get("r");
-      await executor?.interruptSession?.(notebook.uri.toString());
-    };
+    // No interruptHandler on purpose: with one, VS Code never fires per-cell
+    // cancellation tokens (it would interrupt the whole session instead). Relying on
+    // the tokens lets stopping one cell cancel just that cell, while leaving the
+    // others running or queued. "Stop All" is offered separately via interruptSession.
   }
 
   public async initialize(): Promise<void> {
@@ -108,13 +118,37 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return;
     }
 
+    const uri = notebook.uri.toString();
+    this.runsToAbort.delete(uri);
     const snapshot = await this.refreshNotebook(notebook);
     for (const entry of snapshot.chunks) {
+      if (this.runsToAbort.has(uri)) {
+        break;
+      }
       const outcome = await this.executeCell(notebook, entry.cell);
       if (outcome === "redirected") {
         break;
       }
     }
+    this.runsToAbort.delete(uri);
+  }
+
+  // Stops the whole run at once: interrupts the chunk currently running, cancels every
+  // chunk still queued, and breaks any in-flight Run All / multi-cell loop so the
+  // remaining cells never start. The notebook-wide counterpart to cancelling a single
+  // cell from its stop button.
+  public async interruptSession(documentUri?: string): Promise<void> {
+    const notebook = this.resolveNotebook(documentUri);
+    if (!notebook) {
+      return;
+    }
+
+    // A Run All / Run Selected loop executes cells one at a time, so only the running
+    // chunk is ever in the session queue; failQueue + SIGINT alone would stop that one
+    // cell and let the loop march on. This flag makes the loop bail out too.
+    this.runsToAbort.add(notebook.uri.toString());
+    const executor = this.executorRegistry.get("r");
+    await executor?.interruptSession?.(notebook.uri.toString());
   }
 
   public async clearCurrentOutput(documentUri?: string, chunkId?: string): Promise<void> {
@@ -316,6 +350,19 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return "completed";
     }
 
+    const releaseAdmission = await this.acquireExecutionAdmission(notebook.uri.toString());
+    try {
+      return await this.executeAdmittedCell(notebook, cell, releaseAdmission);
+    } finally {
+      releaseAdmission();
+    }
+  }
+
+  private async executeAdmittedCell(
+    notebook: vscode.NotebookDocument,
+    cell: vscode.NotebookCell,
+    releaseAdmission: () => void
+  ): Promise<ExecuteCellOutcome> {
     const snapshot = await this.refreshNotebook(notebook);
     const entry = snapshot.chunks.find((candidate) => candidate.index === cell.index);
     if (!entry) {
@@ -330,10 +377,26 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return "completed";
     }
     const execution = this.controller.createNotebookCellExecution(notebook.cellAt(entry.index));
-    execution.executionOrder = ++this.executionOrder;
-    execution.start(Date.now());
+    // Leave the cell in the "queued" (pending clock) state until the chunk actually
+    // begins running in R, instead of marking it running the moment it is enqueued.
+    // That way every cell's reported duration is its own run time, not the time since
+    // the first queued chunk started, and cells waiting their turn show the queued
+    // badge rather than a spinner, exactly like Run All. start() must precede end(),
+    // so paths that never reach R still call this before ending the execution.
+    let executionStarted = false;
+    const beginExecutionDisplay = (startTime?: number, assignOrder = true): void => {
+      if (executionStarted) {
+        return;
+      }
+      executionStarted = true;
+      if (assignOrder) {
+        execution.executionOrder = ++this.executionOrder;
+      }
+      execution.start(startTime);
+    };
 
     if (chunkOptions?.eval === false) {
+      beginExecutionDisplay(Date.now());
       const skippedRecord = createRecord(entry.chunk, "success", []);
       outputs.set(entry.chunk.identity.chunkId, skippedRecord);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
@@ -346,6 +409,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     }
 
     if (!executor) {
+      beginExecutionDisplay(Date.now());
       const record = createRecord(entry.chunk, "error", [
         {
           type: "error",
@@ -368,7 +432,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     this.outputChannelController.logRunStarted(cell.document, entry.chunk);
 
     try {
-      const result = await executor.executeChunk({
+      const resultPromise = executor.executeChunk({
         documentUri: notebook.uri.toString(),
         workspaceFolder: vscode.workspace.getWorkspaceFolder(notebook.uri)?.uri.fsPath,
         chunkId: entry.chunk.identity.chunkId,
@@ -377,10 +441,20 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         header: entry.chunk.header,
         artifactDirectory: await this.outputStore.getArtifactDirectory(notebook.uri.toString()),
         plot: resolvePlotRenderOptions(chunkOptions),
-        prompt: (request) => this.promptForChunkInput(notebook, cell, entry.chunk, request)
+        prompt: (request) => this.promptForChunkInput(notebook, cell, entry.chunk, request),
+        onStart: () => beginExecutionDisplay(Date.now()),
+        token: execution.token
       });
+      releaseAdmission();
+      const result = await resultPromise;
 
       const filteredResult = applyChunkOptionsToResult(result, chunkOptions);
+      // onStart always fires (in the session's beginExecution) before any result can
+      // arrive, so the cell is already marked running here; this call is only a
+      // fallback for the impossible case where onStart was skipped, and is a no-op
+      // otherwise. The displayed start time therefore comes from onStart (Date.now at
+      // dequeue), not from filteredResult.startedAt.
+      beginExecutionDisplay(filteredResult.startedAt);
       const record = createRecordFromResult(entry.chunk, filteredResult);
       outputs.set(entry.chunk.identity.chunkId, record);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
@@ -396,11 +470,32 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return "completed";
     } catch (error) {
       if (error instanceof InteractiveExecutionError) {
+        // The chunk did start running (it timed out mid-execution), so the cell is
+        // already showing as running by now; this only matters as a safeguard.
+        beginExecutionDisplay(Date.now());
         const fallback = await this.handleInteractiveFallback(notebook, cell, entry.chunk, outputs, execution, error.message);
         this.outputChannelController.logRunCompleted(cell.document, entry.chunk, fallback.record);
         return fallback.launchedTerminal ? "redirected" : "completed";
       }
 
+      if (error instanceof CancelledExecutionError) {
+        // The chunk was interrupted while still waiting in the queue, so it never
+        // ran. End the still-pending execution without assigning a run order or a
+        // duration (start() must be called before end(), but with no start time so
+        // no clock is shown), and clear it without flagging it as a failure.
+        beginExecutionDisplay(undefined, false);
+        const cancelledRecord = createRecord(entry.chunk, "cancelled", []);
+        outputs.set(entry.chunk.identity.chunkId, cancelledRecord);
+        await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
+        await this.withOutputSync(notebook.uri.toString(), async () => {
+          await execution.clearOutput();
+        });
+        execution.end(undefined, Date.now());
+        this.outputChannelController.logRunCompleted(cell.document, entry.chunk, cancelledRecord);
+        return "completed";
+      }
+
+      beginExecutionDisplay(Date.now());
       const record = createRecord(entry.chunk, "error", [
         {
           type: "error",
@@ -416,6 +511,31 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
       return "completed";
     }
+  }
+
+  private async acquireExecutionAdmission(documentUri: string): Promise<() => void> {
+    // Preserve request order through asynchronous notebook preparation. The caller
+    // releases this gate as soon as the request reaches the executor's own queue.
+    const previous = this.executionAdmissions.get(documentUri) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.executionAdmissions.set(documentUri, tail);
+
+    await previous;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      release();
+      if (this.executionAdmissions.get(documentUri) === tail) {
+        this.executionAdmissions.delete(documentUri);
+      }
+    };
   }
 
   public async runCurrentChunkInTerminal(documentUri?: string, chunkId?: string): Promise<void> {
@@ -598,6 +718,14 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   private resolveNotebook(documentUri?: string): vscode.NotebookDocument | undefined {
+    // Toolbar/menu commands are invoked with a context object (e.g. { notebookEditor })
+    // rather than a string URI, so a non-string argument means "no URI given": fall
+    // back to the active/visible notebook instead of comparing a string against an
+    // object (which never matches and would silently resolve nothing).
+    if (typeof documentUri !== "string") {
+      documentUri = undefined;
+    }
+
     if (!documentUri) {
       return (
         vscode.window.activeNotebookEditor?.notebook ??

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -824,6 +824,554 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.equal(vscode.window.terminals.length, 0);
   });
 
+  it("queues a chunk requested while another is still running", async () => {
+    await writeFixture(
+      "queue-order.qmd",
+      [
+        "# Queue order",
+        "",
+        "```{r slow}",
+        "Sys.sleep(2)",
+        "cat('first done\\n')",
+        "```",
+        "",
+        "```{r fast}",
+        "cat('second done\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("queue-order.qmd");
+    const uri = editor.notebook.uri.toString();
+    const before = await extensionApi.getDocumentState(uri);
+    const [slowId, fastId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(slowId && fastId, "Expected two chunk ids.");
+
+    // Start the slow chunk and wait until it is actually executing.
+    const slowRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, slowId);
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === slowId && record.status === "running")
+    );
+
+    // Requesting the second chunk while the first is busy should queue it, not error out.
+    const fastRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, fastId);
+    await Promise.all([slowRun, fastRun]);
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.filter((record) => record.status === "success").length === 2
+    );
+
+    assert.equal(state.outputs.filter((record) => record.status === "success").length, 2);
+    assert.ok(!state.outputChannelText.includes("already executing"), "The queued chunk should not be rejected.");
+    const firstIndex = state.outputChannelText.indexOf("first done");
+    const secondIndex = state.outputChannelText.indexOf("second done");
+    assert.ok(firstIndex >= 0 && secondIndex >= 0, "Both chunks should have produced stdout.");
+    assert.ok(firstIndex < secondIndex, "The queued chunk should run after the one already executing.");
+  });
+
+  it("preserves request order for back-to-back dependent chunks", async () => {
+    // Repeat across fresh sessions so the regression remains reliable without
+    // adding a long-running stress test to every integration-suite run.
+    for (let iteration = 0; iteration < 5; iteration += 1) {
+      const name = `queue-dependent-chain-${iteration}.qmd`;
+      await writeFixture(
+        name,
+        [
+          `# Dependent queue chain ${iteration}`,
+          "",
+          "```{r a}",
+          "queue_a <- 1",
+          "```",
+          "",
+          "```{r b}",
+          "queue_b <- queue_a",
+          "```",
+          "",
+          "```{r c}",
+          "queue_c <- queue_b",
+          "```",
+          "",
+          "```{r d}",
+          "queue_d <- queue_c",
+          "```",
+          "",
+          "```{r e}",
+          "queue_e <- queue_d",
+          "```",
+          "",
+          "```{r result}",
+          `cat("dependent-chain-${iteration}:", queue_e, "\\n")`,
+          "```",
+          ""
+        ].join("\n")
+      );
+
+      const editor = await openNotebookEditor(name);
+      const uri = editor.notebook.uri.toString();
+      const before = await extensionApi.getDocumentState(uri);
+      const chunkIds = before.snapshot?.chunkIds ?? [];
+      assert.equal(chunkIds.length, 6, `Expected six dependent chunk ids in iteration ${iteration}.`);
+
+      // Model rapid individual cell execution, not Run All's explicitly sequential
+      // loop: each request is issued 100ms after the previous request without waiting
+      // for the previous chunk to finish.
+      const runs: Thenable<unknown>[] = [];
+      for (const chunkId of chunkIds) {
+        runs.push(vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, chunkId));
+        await sleep(100);
+      }
+      await Promise.all(runs);
+
+      const state = await extensionApi.getDocumentState(uri);
+      assert.equal(
+        state.outputs.filter((record) => record.status === "success").length,
+        chunkIds.length,
+        `Every dependent chunk should execute in requested order in iteration ${iteration}. ${state.outputChannelText}`
+      );
+      assert.ok(state.outputChannelText.includes(`dependent-chain-${iteration}: 1`));
+      await closeAllEditors();
+    }
+  });
+
+  it("stops the whole run, interrupting the running chunk and cancelling the queued ones", async () => {
+    await writeFixture(
+      "queue-interrupt.qmd",
+      [
+        "# Queue interrupt",
+        "",
+        "```{r blocking}",
+        "Sys.sleep(30)",
+        "cat('blocking done\\n')",
+        "```",
+        "",
+        "```{r waiting}",
+        "cat('waiting done\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    // Keep the interactive timeout out of the way: the chunk is meant to be
+    // stopped by the interrupt, not by the fallback.
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 60000);
+
+    const editor = await openNotebookEditor("queue-interrupt.qmd");
+    const uri = editor.notebook.uri.toString();
+    const before = await extensionApi.getDocumentState(uri);
+    const [blockingId, waitingId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(blockingId && waitingId, "Expected two chunk ids.");
+
+    const blockingRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, blockingId);
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === blockingId && record.status === "running")
+    );
+
+    const waitingRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, waitingId);
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === waitingId && record.status === "running")
+    );
+    // Give the queued chunk a moment to actually enter the session queue before
+    // interrupting, so the interrupt is guaranteed to catch it waiting.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    await vscode.commands.executeCommand("rmdNotebooks.interruptSession", uri);
+    await Promise.all([blockingRun, waitingRun]);
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) => {
+      const blocking = candidate.outputs.find((record) => record.chunkId === blockingId);
+      const waiting = candidate.outputs.find((record) => record.chunkId === waitingId);
+      return blocking?.status === "error" && waiting?.status === "cancelled";
+    });
+
+    const blocking = state.outputs.find((record) => record.chunkId === blockingId);
+    const waiting = state.outputs.find((record) => record.chunkId === waitingId);
+    assert.equal(blocking?.status, "error");
+    assert.equal(waiting?.status, "cancelled");
+    assert.ok(!state.outputChannelText.includes("blocking done"), "The interrupted chunk should not finish.");
+    assert.ok(!state.outputChannelText.includes("waiting done"), "The cancelled chunk should never run.");
+  });
+
+  it("stops a Run All in progress so the remaining chunks do not run", async () => {
+    await writeFixture(
+      "runall-stop.qmd",
+      [
+        "# Run all stop",
+        "",
+        "```{r warm}",
+        "1 + 1",
+        "```",
+        "",
+        "```{r slow}",
+        "Sys.sleep(10)",
+        "cat('runall-slow done\\n')",
+        "```",
+        "",
+        "```{r mid}",
+        "cat('runall-mid done\\n')",
+        "```",
+        "",
+        "```{r tail}",
+        "cat('runall-tail done\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 60000);
+
+    const editor = await openNotebookEditor("runall-stop.qmd");
+    const uri = editor.notebook.uri;
+    const before = await extensionApi.getDocumentState(uri.toString());
+    const [, slowId, midId, tailId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(slowId && midId && tailId, "Expected four chunk ids.");
+
+    // Run every chunk. The warm-up chunk runs first (so the session is ready by the
+    // time the slow chunk starts), then the slow Sys.sleep(10) chunk runs while mid and
+    // tail wait their turn in the run loop.
+    const runAll = vscode.commands.executeCommand("rmdNotebooks.runAllChunks", uri.toString());
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === slowId && record.status === "running")
+    );
+    await sleep(400);
+
+    // Stop All during a Run All must end the WHOLE run, not just interrupt the current
+    // cell and let the loop march on to the next one.
+    await vscode.commands.executeCommand("rmdNotebooks.interruptSession", uri.toString());
+    await runAll;
+
+    const state = await waitForDocumentState(
+      uri,
+      (candidate) => {
+        const slow = candidate.outputs.find((record) => record.chunkId === slowId);
+        return !!slow && slow.status !== "running";
+      },
+      15000
+    );
+
+    const slow = state.outputs.find((record) => record.chunkId === slowId);
+    assert.ok(slow && slow.status !== "success", `The interrupted chunk should not complete, got ${slow?.status}.`);
+    assert.ok(!state.outputChannelText.includes("runall-slow done"), "The interrupted chunk should not finish.");
+    assert.ok(!state.outputChannelText.includes("runall-mid done"), "Run All must not continue to the next chunk after Stop All.");
+    assert.ok(!state.outputChannelText.includes("runall-tail done"), "Run All must not continue to later chunks after Stop All.");
+  });
+
+  it("cancels only the targeted queued chunk and lets the others run", async () => {
+    await writeFixture(
+      "cancel-one.qmd",
+      [
+        "# Cancel one",
+        "",
+        "```{r runningchunk}",
+        "Sys.sleep(3)",
+        "cat('running done\\n')",
+        "```",
+        "",
+        "```{r cancelme}",
+        "cat('cancelme done\\n')",
+        "```",
+        "",
+        "```{r survivor}",
+        "cat('survivor done\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 60000);
+
+    const editor = await openNotebookEditor("cancel-one.qmd");
+    const uri = editor.notebook.uri;
+    const before = await extensionApi.getDocumentState(uri.toString());
+    const [runningId, cancelId, survivorId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(runningId && cancelId && survivorId, "Expected three chunk ids.");
+
+    const cancelIndex = findCodeCellIndex(editor.notebook, "cancelme done");
+
+    // Queue all three: the first runs (~3s), the other two wait behind it.
+    const runningRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), runningId);
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === runningId && record.status === "running")
+    );
+    const cancelRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), cancelId);
+    const survivorRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), survivorId);
+    await waitForDocumentState(uri, (candidate) =>
+      [cancelId, survivorId].every((id) => candidate.outputs.some((record) => record.chunkId === id))
+    );
+    // Let the two trailing chunks settle into the session queue behind the running one.
+    await sleep(300);
+
+    // Stop just the middle chunk from its own cell, the way its stop button would.
+    editor.selection = singleCellRange(cancelIndex);
+    await vscode.commands.executeCommand("notebook.cell.cancelExecution");
+
+    await Promise.all([runningRun, cancelRun, survivorRun]);
+
+    const state = await waitForDocumentState(uri, (candidate) => {
+      const running = candidate.outputs.find((record) => record.chunkId === runningId);
+      const cancelled = candidate.outputs.find((record) => record.chunkId === cancelId);
+      const survivor = candidate.outputs.find((record) => record.chunkId === survivorId);
+      return running?.status === "success" && cancelled?.status === "cancelled" && survivor?.status === "success";
+    });
+
+    assert.equal(state.outputs.find((record) => record.chunkId === cancelId)?.status, "cancelled");
+    assert.equal(state.outputs.find((record) => record.chunkId === runningId)?.status, "success");
+    assert.equal(state.outputs.find((record) => record.chunkId === survivorId)?.status, "success");
+    assert.ok(state.outputChannelText.includes("running done"), "The running chunk should finish.");
+    assert.ok(state.outputChannelText.includes("survivor done"), "The chunk after the cancelled one should run.");
+    assert.ok(!state.outputChannelText.includes("cancelme done"), "The cancelled chunk should never run.");
+  });
+
+  it("interrupts only the running cell and lets the queue continue", async () => {
+    await writeFixture(
+      "cancel-running.qmd",
+      [
+        "# Cancel running",
+        "",
+        "```{r warmup}",
+        "1 + 1",
+        "```",
+        "",
+        "```{r runningchunk}",
+        "Sys.sleep(30)",
+        "cat('running-cell finished\\n')",
+        "```",
+        "",
+        "```{r nextchunk}",
+        "cat('after-interrupt ran\\n')",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 60000);
+
+    const editor = await openNotebookEditor("cancel-running.qmd");
+    const uri = editor.notebook.uri;
+    const before = await extensionApi.getDocumentState(uri.toString());
+    const [warmupId, runningId, nextId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(warmupId && runningId && nextId, "Expected three chunk ids.");
+
+    const runningIndex = findCodeCellIndex(editor.notebook, "running-cell finished");
+
+    // Warm the session so the long chunk begins running within microseconds of being
+    // enqueued; otherwise it could still be queued when we cancel and get dropped
+    // (cancelled) instead of interrupted (error).
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), warmupId);
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === warmupId && record.status === "success")
+    );
+
+    // Start the long chunk, then queue another behind it.
+    const runningRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), runningId);
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === runningId && record.status === "running")
+    );
+    const nextRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), nextId);
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === nextId)
+    );
+    // Let the long chunk actually begin in R and the next one settle in the queue.
+    await sleep(400);
+
+    // Stop just the running cell from its own stop button: it should be interrupted
+    // while the queued chunk behind it keeps going.
+    editor.selection = singleCellRange(runningIndex);
+    await vscode.commands.executeCommand("notebook.cell.cancelExecution");
+
+    await Promise.all([runningRun, nextRun]);
+
+    const state = await waitForDocumentState(uri, (candidate) => {
+      const running = candidate.outputs.find((record) => record.chunkId === runningId);
+      const next = candidate.outputs.find((record) => record.chunkId === nextId);
+      return running?.status === "error" && next?.status === "success";
+    });
+
+    assert.equal(
+      state.outputs.find((record) => record.chunkId === runningId)?.status,
+      "error",
+      "The running cell should be interrupted."
+    );
+    assert.equal(
+      state.outputs.find((record) => record.chunkId === nextId)?.status,
+      "success",
+      "The queued cell should still run after the running one is interrupted."
+    );
+    assert.ok(!state.outputChannelText.includes("running-cell finished"), "The interrupted cell should not finish.");
+    assert.ok(state.outputChannelText.includes("after-interrupt ran"), "The queue should continue after the interrupt.");
+  });
+
+  it("times each queued chunk by its own run, not the time since the first one started", async () => {
+    await writeFixture(
+      "queue-timing.qmd",
+      [
+        "# Queue timing",
+        "",
+        "```{r firstsleep}",
+        "Sys.sleep(1)",
+        "```",
+        "",
+        "```{r secondsleep}",
+        "Sys.sleep(1)",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("queue-timing.qmd");
+    const uri = editor.notebook.uri.toString();
+    const before = await extensionApi.getDocumentState(uri);
+    const [firstId, secondId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(firstId && secondId, "Expected two chunk ids.");
+
+    const firstIndex = findFirstCodeCellIndex(editor.notebook);
+    const secondIndex = findLastCodeCellIndex(editor.notebook);
+
+    // Queue both chunks back-to-back so the second waits behind the first, just like
+    // running two cells in quick succession.
+    const firstRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, firstId);
+    const secondRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, secondId);
+    await Promise.all([firstRun, secondRun]);
+
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.filter((record) => record.status === "success").length === 2
+    );
+
+    const firstTiming = await waitForCellTiming(editor.notebook.uri, firstIndex);
+    const secondTiming = await waitForCellTiming(editor.notebook.uri, secondIndex);
+
+    const firstDuration = firstTiming.endTime - firstTiming.startTime;
+    const secondDuration = secondTiming.endTime - secondTiming.startTime;
+
+    // Each cell should report roughly its own ~1s sleep. Before the fix the second
+    // cell's clock started when it was enqueued (alongside the first), so it reported
+    // ~2s (the elapsed time since the first chunk began) instead of its own ~1s.
+    assert.ok(
+      firstDuration < 1800,
+      `First chunk should report ~its own 1s run, got ${firstDuration}ms.`
+    );
+    assert.ok(
+      secondDuration < 1800,
+      `Second chunk should report ~its own 1s run, not the cumulative time, got ${secondDuration}ms.`
+    );
+    // The two chunks ran sequentially (the queued one only started once the running
+    // one finished), confirming the clock reflects the queue wait rather than the
+    // enqueue moment. Order-independent: the two un-awaited runs can enqueue in either
+    // order, so compare the later start against the earlier end rather than assuming
+    // which chunk ran first.
+    const laterStart = Math.max(firstTiming.startTime, secondTiming.startTime);
+    const earlierEnd = Math.min(firstTiming.endTime, secondTiming.endTime);
+    assert.ok(
+      laterStart >= earlierEnd - 250,
+      `The second chunk should start when the first finished (later start ${laterStart}, earlier end ${earlierEnd}).`
+    );
+  });
+
+  it("interrupts a running chunk even after an earlier interrupt in the same session", async () => {
+    await writeFixture(
+      "double-interrupt.qmd",
+      [
+        "# Double interrupt",
+        "",
+        "```{r warmup}",
+        "1 + 1",
+        "```",
+        "",
+        "```{r blockingone}",
+        "Sys.sleep(10)",
+        "```",
+        "",
+        "```{r blockingtwo}",
+        "Sys.sleep(10)",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    // Keep the interactive-fallback timeout out of the way so each chunk is stopped by
+    // the interrupt, not by the timeout.
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 60000);
+
+    const editor = await openNotebookEditor("double-interrupt.qmd");
+    const uri = editor.notebook.uri;
+    const before = await extensionApi.getDocumentState(uri.toString());
+    const [warmupId, firstId, secondId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(warmupId && firstId && secondId, "Expected three chunk ids.");
+
+    // Warm the session up first so a queued chunk begins running within microseconds
+    // of being enqueued, making the interrupt timing below deterministic.
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), warmupId);
+    await waitForDocumentState(uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === warmupId && record.status === "success")
+    );
+
+    // Interrupt the first chunk while it runs.
+    await interruptRunningChunk(uri, firstId);
+
+    // Interrupt a second chunk in the SAME session: this is the regression. Before the
+    // fix the second SIGINT was skipped (child.killed stays true after the first kill,
+    // even though the session survives it), so the chunk ran to completion instead of
+    // stopping while the queued chunks still got cancelled.
+    await interruptRunningChunk(uri, secondId);
+  });
+
+  it("runs a queued chunk after the one ahead of it times out", async () => {
+    await writeFixture(
+      "queue-after-timeout.qmd",
+      [
+        "# Queue after timeout",
+        "",
+        "```{r slow}",
+        "x <- 42",
+        "Sys.sleep(2)",
+        "```",
+        "",
+        "```{r queued}",
+        "cat(sprintf('queued ran x=%s\\n', x))",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    // The chunk ahead hits the interactive-fallback timeout (reported as an error,
+    // not redirected to a terminal). The queued chunk must not stay wedged behind
+    // the abandoned execution: once the interrupted chunk emits RESULT_END the queue
+    // drains and the queued chunk runs in the same still-live session.
+    await updateTestSetting("execution.interactiveFallbackTimeoutMs", 1000);
+    await updateTestSetting("execution.interactiveFallbackBehavior", "error");
+
+    const editor = await openNotebookEditor("queue-after-timeout.qmd");
+    const uri = editor.notebook.uri.toString();
+    const before = await extensionApi.getDocumentState(uri);
+    const [slowId, queuedId] = before.snapshot?.chunkIds ?? [];
+    assert.ok(slowId && queuedId, "Expected two chunk ids.");
+
+    // Start the slow chunk, wait until it is actually executing, then queue the
+    // second one behind it before the timeout fires.
+    const slowRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, slowId);
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.chunkId === slowId && record.status === "running")
+    );
+
+    const queuedRun = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri, queuedId);
+    await Promise.all([slowRun, queuedRun]);
+
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) => {
+      const slow = candidate.outputs.find((record) => record.chunkId === slowId);
+      const queued = candidate.outputs.find((record) => record.chunkId === queuedId);
+      return slow?.status === "error" && queued?.status === "success";
+    });
+
+    const slow = state.outputs.find((record) => record.chunkId === slowId);
+    const queued = state.outputs.find((record) => record.chunkId === queuedId);
+    assert.equal(slow?.status, "error", "The chunk ahead should hit the inline timeout.");
+    assert.equal(queued?.status, "success", "The queued chunk should run after the timeout, not hang behind it.");
+    assert.ok(
+      state.outputChannelText.includes("queued ran x=42"),
+      "The queued chunk should execute in the same live session."
+    );
+  });
+
   it("handles readline() prompts inline with a text input", async () => {
     await writeFixture(
       "interactive-readline.qmd",
@@ -967,14 +1515,55 @@ async function waitForNotebookOutput(
   }, timeoutMs);
 }
 
+async function interruptRunningChunk(uri: vscode.Uri, chunkId: string): Promise<void> {
+  const run = vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk", uri.toString(), chunkId);
+  await waitForDocumentState(uri, (candidate) =>
+    candidate.outputs.some((record) => record.chunkId === chunkId && record.status === "running")
+  );
+  // The "running" status is set just before the chunk is handed to R, so give it a
+  // moment to actually begin executing; interrupting during that window would cancel
+  // it (as still-queued) instead of interrupting the running chunk.
+  await sleep(400);
+  await vscode.commands.executeCommand("rmdNotebooks.interruptSession", uri.toString());
+
+  // A working interrupt terminates the chunk (status "error") almost immediately.
+  // Bound the wait and accept any terminal status so a regression (the SIGINT is
+  // skipped and the chunk runs to completion -> "success") fails fast with a targeted
+  // assertion instead of via the 60s mocha timeout.
+  const state = await waitForDocumentState(
+    uri,
+    (candidate) => {
+      const record = candidate.outputs.find((entry) => entry.chunkId === chunkId);
+      return !!record && (record.status === "error" || record.status === "success" || record.status === "cancelled");
+    },
+    15000
+  );
+  const record = state.outputs.find((entry) => entry.chunkId === chunkId);
+  assert.equal(record?.status, "error", `Chunk ${chunkId} should be interrupted (status error), got ${record?.status}.`);
+  await run.then(undefined, () => undefined);
+}
+
+async function waitForCellTiming(
+  uri: vscode.Uri,
+  cellIndex: number,
+  timeoutMs = 30000
+): Promise<{ startTime: number; endTime: number }> {
+  return waitFor(() => {
+    const notebook = vscode.workspace.notebookDocuments.find((candidate) => candidate.uri.toString() === uri.toString());
+    const timing = notebook?.cellAt(cellIndex).executionSummary?.timing;
+    return timing && timing.endTime >= timing.startTime ? timing : undefined;
+  }, timeoutMs);
+}
+
 async function waitForDocumentState(
   uri: vscode.Uri,
-  predicate: (state: Awaited<ReturnType<InlineChunksExtensionApi["getDocumentState"]>>) => boolean
+  predicate: (state: Awaited<ReturnType<InlineChunksExtensionApi["getDocumentState"]>>) => boolean,
+  timeoutMs = 30000
 ): Promise<Awaited<ReturnType<InlineChunksExtensionApi["getDocumentState"]>>> {
   return waitFor(async () => {
     const state = await extensionApi.getDocumentState(uri.toString());
     return predicate(state) ? state : undefined;
-  });
+  }, timeoutMs);
 }
 
 async function waitFor<T>(producer: () => Promise<T | undefined> | T | undefined, timeoutMs = 30000): Promise<T> {

--- a/test/vscode/suite/index.ts
+++ b/test/vscode/suite/index.ts
@@ -9,6 +9,12 @@ export function run(): Promise<void> {
     timeout: 60000
   });
 
+  // Optional focus filter for local runs, e.g. RMD_NOTEBOOKS_TEST_GREP="interrupt".
+  const grep = process.env.RMD_NOTEBOOKS_TEST_GREP;
+  if (grep) {
+    mocha.grep(grep);
+  }
+
   const testsRoot = __dirname;
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

> Stacked on #12 (which is itself stacked on #11). Until #11 and #12 merge into `main`, their commits and files show up in this diff. Merge order: #11, then #12, then this.

Running a chunk while another was still executing failed with "R session is already executing a chunk." This makes inline chunks **queue** instead: a chunk requested while another is running waits its turn and runs in order, like cells in a Jupyter notebook. On top of the queue this PR adds Jupyter-like execution UX:

- **Per-cell cancellation.** Each cell's stop button cancels just that cell: a queued cell is dropped from the queue, the running cell is interrupted, and the rest keep going.
- **Stop All.** A toolbar/command-palette action interrupts the running chunk, cancels the whole queue, and stops an in-flight Run All.
- **Queued chunks show as pending** (the clock badge), not a spinner, and each cell reports **its own run time** rather than the time elapsed since the first queued chunk started.

It also fixes two defects in the original queue/interrupt behavior:

- A chunk could not be interrupted after the first interrupt in a session: `interruptProcess` guarded on `process.killed`, which Node leaves `true` after the first `kill()` even though R survives a SIGINT, so every later interrupt was a no-op.
- Running several cells in quick succession showed cumulative durations (5s, 10s, 15s) because a cell's clock started when it was enqueued, not when it actually began running.

## Minimal reproduction

A throwaway workspace outside the repo so the branch stays clean, `/tmp/queue-test/`:

`/tmp/queue-test/queue.qmd`
````
# Queue

```{r a}
Sys.sleep(5)
```

```{r b}
Sys.sleep(5)
```

```{r c}
Sys.sleep(5)
```
````

Steps (F5 dev host, open `/tmp/queue-test/`, open `queue.qmd` as a notebook):
1. Run cells `a`, `b`, `c` in quick succession.
   - Before: each shows a spinner immediately and the durations are cumulative (≈5s, ≈10s, ≈15s).
   - After: `a` runs while `b` and `c` show the pending (clock) badge, and each reports ≈5s.
2. While `a` runs and `b`, `c` are queued, click the stop button on cell `c`.
   - After: only `c` is cancelled; `a` keeps running and `b` still runs after it.
3. While a chunk runs, click the stop button on that running cell, then run another chunk and stop it too.
   - Before: the second stop was a no-op and the chunk ran to completion.
   - After: both are interrupted.
4. Start Run All over the three cells, then press the toolbar "Stop All".
   - After: the running cell is interrupted and the remaining cells do not run.

The before/after is the scenario locked down by the integration tests below, and I also walked through every step by hand in the dev host.

## Motivation / Design

`RSession.execute()` rejected a second call outright while one was in flight; the R session is inherently single-flight (one command loop over stdin/stdout), so the constraint is real, but erroring is the wrong response. Both execution entry points (the notebook controller and the editor code lens) go through the same per-document `RSession`, so the fix belongs there.

- `execute()` pushes an `ExecutionRequest` onto a queue and returns a promise; `drainQueue()` starts the next chunk only once the session is idle and ready, so requests run strictly FIFO.
- **Per-cell cancellation via tokens.** The notebook controller no longer sets an `interruptHandler` (VS Code never fires per-cell `NotebookCellExecution.token` cancellation while one is set, and the API recommends tokens when executions can be tracked, which the queue does). Each cell passes its token to the executor; `cancelTask` drops the task if it is still queued (status `cancelled`) or SIGINTs it if it is the one running, leaving the rest of the queue intact.
- **Stop All** (`rmdNotebooks.interruptSession`) rejects every queued request with `CancelledExecutionError`, SIGINTs the running chunk, and sets a per-notebook flag the Run All / multi-cell loops check between cells so the run stops instead of marching on.
- **Deferred start.** The cell's `NotebookCellExecution` is created up front (pending/clock badge) and `start()` is called only when the chunk actually begins running in R (a new `onStart` hook fired from `beginExecution`), so a queued cell stays pending and each cell's reported duration is its own run time.
- **Reliable interrupts.** `interruptProcess` guards on session liveness (`alive`) instead of `process.killed`, which stays `true` after the first `kill()`.
- `alive` guards the queue against a dead process: if the session exits or is disposed, pending and queued requests are rejected instead of writing to a closed stdin.

The R command loop gains an `interrupt` handler in its `tryCatch`, so an interrupted chunk still emits a clean `RESULT_END` and the protocol stays in sync. Queued chunks that get interrupted never ran, so a new `cancelled` status clears the cell output and ends the execution with no pass/fail mark (the code lens shows `[cancelled]`).

### Overlap with upstream interrupt work

`main` already wires an `interruptHandler` but `RExecutor` never implemented `interruptSession`, so the button was inert. This PR replaces that notebook-wide handler with per-cell tokens plus an explicit Stop All; a small conflict in `RSession` is likely if upstream interrupt work (#8/#10) lands first, and it is trivial to resolve.

## Changes

- `src/execution/rExecutor.ts`: FIFO queue (`drainQueue`/`beginExecution`/`failQueue`); `onStart` hook; per-chunk `cancelTask` with `pendingTask` tracking and an optional cancellation token; `interrupt()`/`interruptProcess()` guarding on `alive` (not `process.killed`); `RExecutor.interruptSession()`.
- `src/execution/executorTypes.ts`: add `onStart` and a `token` (structural `ExecutionCancellationToken`) to `ExecutionContext`.
- `src/execution/executionErrors.ts`: add `CancelledExecutionError`.
- `media/r/rmd_notebooks_session.R`: handle the `interrupt` condition so an interrupted chunk reports a clean failed result.
- `src/document/chunkTypes.ts`: add `cancelled` to `ChunkOutputStatus`.
- `src/notebook/notebookRuntime.ts`: defer `execution.start()` to `onStart`; pass each cell's token; drop the notebook-wide `interruptHandler`; add `interruptSession` ("Stop All") with a run-loop abort flag; normalize toolbar command arguments that arrive as a context object rather than a URI string.
- `src/commands/registerCommands.ts`, `package.json`: register and contribute the `rmdNotebooks.interruptSession` command and its toolbar button.
- `src/editor/editorController.ts`, `src/editor/outputPreview.ts`, `src/editor/outputChannelController.ts`: render the `cancelled` status / end a cancelled queued chunk without a red error.
- `test/vscode/suite/extensionHost.test.ts`, `test/vscode/suite/index.ts`: integration tests (below) plus an opt-in `RMD_NOTEBOOKS_TEST_GREP` focus filter for the runner.

## Test plan

- [x] `npm run test:unit`: 33 tests pass.
- [x] `npm run test:vscode`: 32 integration tests pass on this branch's contents. The queue/interrupt behavior is covered by:
  - "queues a chunk requested while another is still running"
  - "stops the whole run, interrupting the running chunk and cancelling the queued ones"
  - "stops a Run All in progress so the remaining chunks do not run"
  - "cancels only the targeted queued chunk and lets the others run"
  - "interrupts only the running cell and lets the queue continue"
  - "times each queued chunk by its own run, not the time since the first one started"
  - "interrupts a running chunk even after an earlier interrupt in the same session"
  - "runs a queued chunk after the one ahead of it times out"
- [x] Verified by hand in the F5 dev host: queue ordering and pending badges, per-cell stop, Stop All, and repeated interrupts all behave as described above.
