### PR TITLE
feat: render R data frames as Jupyter-style HTML tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ The notebook toolbar also exposes `Restart R Session` and `View Source`.
 - `rmdNotebooks.r.sourceVscodeRSessionWatcher`: source `~/.vscode-R/init.R` in inline R sessions when present. Defaults to `true`.
 - `rmdNotebooks.execution.interactiveFallbackTimeoutMs`: timeout for treating a stalled inline chunk as unsupported interactive input. Defaults to `0`, which disables the timeout.
 - `rmdNotebooks.execution.interactiveFallbackBehavior`: what to do when the optional interactive fallback timeout fires. Defaults to `prompt`.
+- `rmdNotebooks.output.dataFrameRender`: render data frames as HTML tables instead of plain text. Defaults to `true`.
+- `rmdNotebooks.output.dataFrameMaxRows`: row threshold before HTML tables collapse to their first and last rows. Defaults to `50`.
+- `rmdNotebooks.output.dataFrameMaxColumns`: column threshold before HTML tables collapse to their first and last columns. Defaults to `50`.
 
 Inline R sessions honor normal startup files by default. To isolate inline sessions from project startup files, add `--vanilla`:
 

--- a/media/r/rmd_notebooks_session.R
+++ b/media/r/rmd_notebooks_session.R
@@ -43,19 +43,63 @@ rmd_notebooks_escape_html <- function(text) {
   text
 }
 
-rmd_notebooks_format_rows <- function(display) {
-  column_count <- length(display)
-  formatted <- lapply(seq_len(column_count), function(index) {
-    column <- display[[index]]
-    rendered <- format(column, trim = TRUE, justify = "left")
-    rendered[is.na(column)] <- "NA"
-    rmd_notebooks_escape_html(rendered)
-  })
-  row_labels <- rmd_notebooks_escape_html(rownames(display))
-  row_count <- nrow(display)
+rmd_notebooks_truncation_plan <- function(total, max_items, shown_cap) {
+  truncated <- is.finite(max_items) && max_items > 0 && total > max_items
+  shown <- if (truncated) min(shown_cap, as.integer(max_items)) else total
+  head_count <- as.integer(ceiling(shown / 2))
+  tail_count <- shown - head_count
+  indices <- c(
+    if (head_count > 0) seq_len(head_count) else integer(),
+    if (tail_count > 0) seq.int(total - tail_count + 1L, total) else integer()
+  )
+  list(truncated = truncated, indices = indices, head_count = head_count, tail_count = tail_count)
+}
 
-  vapply(seq_len(row_count), function(row_index) {
-    cells <- vapply(formatted, function(column) column[row_index], character(1))
+rmd_notebooks_format_data_frame <- function(df, row_indices, column_indices) {
+  selected_rows <- as.data.frame(df[row_indices, , drop = FALSE])
+  selected <- selected_rows[, column_indices, drop = FALSE]
+  if (ncol(selected) == 0) {
+    return(matrix(character(), nrow = nrow(selected), ncol = 0))
+  }
+  as.matrix(format(selected, trim = TRUE, justify = "left"))
+}
+
+rmd_notebooks_truncate_formatted_columns <- function(display, max_columns, force = FALSE) {
+  plan <- rmd_notebooks_truncation_plan(ncol(display), max_columns, 20L)
+  if (!force && !plan$truncated) {
+    return(display)
+  }
+
+  if (!plan$truncated) {
+    shown <- min(20L, as.integer(max_columns), ncol(display))
+    plan$head_count <- as.integer(ceiling(shown / 2))
+    plan$tail_count <- shown - plan$head_count
+    plan$indices <- c(
+      if (plan$head_count > 0) seq_len(plan$head_count) else integer(),
+      if (plan$tail_count > 0) seq.int(ncol(display) - plan$tail_count + 1L, ncol(display)) else integer()
+    )
+  }
+
+  head_columns <- if (plan$head_count > 0) display[, utils::head(plan$indices, plan$head_count), drop = FALSE] else NULL
+  tail_columns <- if (plan$tail_count > 0) display[, utils::tail(plan$indices, plan$tail_count), drop = FALSE] else NULL
+  ellipsis <- matrix(rep("...", nrow(display)), ncol = 1, dimnames = list(NULL, "..."))
+  do.call(cbind, Filter(Negate(is.null), list(head_columns, ellipsis, tail_columns)))
+}
+
+rmd_notebooks_format_rows <- function(display, row_labels) {
+  escaped <- if (ncol(display) == 0) {
+    matrix(character(), nrow = nrow(display), ncol = 0)
+  } else {
+    result <- apply(display, 2, rmd_notebooks_escape_html)
+    if (is.null(dim(result))) {
+      result <- matrix(result, nrow = nrow(display), dimnames = dimnames(display))
+    }
+    result
+  }
+  row_labels <- rmd_notebooks_escape_html(row_labels)
+
+  vapply(seq_len(nrow(display)), function(row_index) {
+    cells <- escaped[row_index, , drop = TRUE]
     sprintf(
       "<tr><th>%s</th>%s</tr>",
       if (length(row_labels) >= row_index) row_labels[row_index] else "",
@@ -64,37 +108,35 @@ rmd_notebooks_format_rows <- function(display) {
   }, character(1))
 }
 
-rmd_notebooks_data_frame_to_html <- function(df, max_rows) {
+rmd_notebooks_data_frame_to_html <- function(df, max_rows, max_columns) {
   total_rows <- nrow(df)
   total_cols <- ncol(df)
-  # Replicate pandas: show every row up to max_rows; once exceeded, collapse to the
-  # first and last rows (min_rows, capped at max_rows) with an ellipsis row between.
-  truncated <- is.finite(max_rows) && max_rows > 0 && total_rows > max_rows
+  row_plan <- rmd_notebooks_truncation_plan(total_rows, max_rows, 10L)
+  column_plan <- rmd_notebooks_truncation_plan(total_cols, max_columns, 20L)
+  display <- rmd_notebooks_format_data_frame(df, row_plan$indices, column_plan$indices)
+  display <- rmd_notebooks_truncate_formatted_columns(display, max_columns, column_plan$truncated)
 
-  body_rows <- character()
-  if (truncated) {
-    shown <- min(10L, as.integer(max_rows))
-    head_count <- as.integer(ceiling(shown / 2))
-    tail_count <- shown - head_count
-    head_rows <- rmd_notebooks_format_rows(head(df, head_count))
+  row_labels <- rownames(df)[row_plan$indices]
+  formatted_rows <- rmd_notebooks_format_rows(display, row_labels)
+  body_rows <- formatted_rows
+  if (row_plan$truncated) {
     ellipsis <- sprintf(
       "<tr class=\"rmd-df-ellipsis\"><th>...</th>%s</tr>",
-      paste(rep("<td>...</td>", total_cols), collapse = "")
+      paste(rep("<td>...</td>", ncol(display)), collapse = "")
     )
-    body_rows <- c(head_rows, ellipsis)
-    if (tail_count > 0) {
-      body_rows <- c(body_rows, rmd_notebooks_format_rows(tail(df, tail_count)))
-    }
-  } else {
-    body_rows <- rmd_notebooks_format_rows(df)
+    body_rows <- append(formatted_rows, ellipsis, after = row_plan$head_count)
   }
 
-  header_cells <- paste0("<th>", rmd_notebooks_escape_html(names(df)), "</th>", collapse = "")
+  header_cells <- if (ncol(display) > 0) {
+    paste0("<th>", rmd_notebooks_escape_html(colnames(display)), "</th>", collapse = "")
+  } else {
+    ""
+  }
   thead <- sprintf("<thead><tr><th></th>%s</tr></thead>", header_cells)
   tbody <- sprintf("<tbody>%s</tbody>", paste(body_rows, collapse = ""))
 
   # pandas only prints the dimensions line when the frame is truncated.
-  meta <- if (truncated) {
+  meta <- if (row_plan$truncated || column_plan$truncated || ncol(display) > max_columns) {
     sprintf("<p class=\"rmd-df-meta\">%d rows &times; %d columns</p>", total_rows, total_cols)
   } else {
     ""
@@ -370,7 +412,7 @@ rmd_notebooks_update_vscode_r_workspace <- function() {
   })
 }
 
-rmd_notebooks_execute <- function(code, working_directory, artifact_directory, plot_width_in, plot_height_in, plot_dpi, df_render, df_max_rows) {
+rmd_notebooks_execute <- function(code, working_directory, artifact_directory, plot_width_in, plot_height_in, plot_dpi, df_render, df_max_rows, df_max_columns) {
   if (nzchar(working_directory) && dir.exists(working_directory)) {
     setwd(working_directory)
   }
@@ -412,7 +454,7 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
         if (result$visible && !is.null(result$value)) {
           html_output <- rmd_notebooks_render_html(result$value)
           if (is.null(html_output) && isTRUE(df_render) && is.data.frame(result$value)) {
-            html_output <- rmd_notebooks_data_frame_to_html(result$value, df_max_rows)
+            html_output <- rmd_notebooks_data_frame_to_html(result$value, df_max_rows, df_max_columns)
           }
           if (!is.null(html_output)) {
             html_buffer <- c(html_buffer, html_output)
@@ -478,7 +520,7 @@ repeat {
     break
   }
 
-  if (!identical(command, "RMD_NOTEBOOKS_COMMAND_V1")) {
+  if (!identical(command, "RMD_NOTEBOOKS_COMMAND_V2")) {
     next
   }
 
@@ -489,6 +531,7 @@ repeat {
   plot_dpi <- readLines(con = stdin(), n = 1, warn = FALSE)
   df_render_line <- readLines(con = stdin(), n = 1, warn = FALSE)
   df_max_rows_line <- readLines(con = stdin(), n = 1, warn = FALSE)
+  df_max_columns_line <- readLines(con = stdin(), n = 1, warn = FALSE)
   code_count_line <- readLines(con = stdin(), n = 1, warn = FALSE)
 
   working_directory <- sub("^WORKDIR:", "", working_directory)
@@ -497,9 +540,13 @@ repeat {
   plot_height_in <- sub("^PLOT_HEIGHT:", "", plot_height_in)
   plot_dpi <- sub("^PLOT_DPI:", "", plot_dpi)
   df_render <- !identical(sub("^DF_RENDER:", "", df_render_line), "0")
-  df_max_rows <- suppressWarnings(as.numeric(sub("^DF_MAX_ROWS:", "", df_max_rows_line)))
+  df_max_rows <- suppressWarnings(as.integer(sub("^DF_MAX_ROWS:", "", df_max_rows_line)))
   if (!is.finite(df_max_rows) || df_max_rows < 1) {
     df_max_rows <- 50
+  }
+  df_max_columns <- suppressWarnings(as.integer(sub("^DF_MAX_COLUMNS:", "", df_max_columns_line)))
+  if (!is.finite(df_max_columns) || df_max_columns < 1) {
+    df_max_columns <- 50
   }
   code_count <- suppressWarnings(as.integer(sub("^CODE_COUNT:", "", code_count_line)))
   if (!is.finite(code_count) || code_count < 0) {
@@ -530,7 +577,8 @@ repeat {
     suppressWarnings(as.numeric(plot_height_in)),
     suppressWarnings(as.numeric(plot_dpi)),
     df_render,
-    df_max_rows
+    df_max_rows,
+    df_max_columns
   )
 
   cat("RMD_NOTEBOOKS_RESULT_START\n")

--- a/media/r/rmd_notebooks_session.R
+++ b/media/r/rmd_notebooks_session.R
@@ -35,6 +35,92 @@ rmd_notebooks_render_html <- function(value) {
   NULL
 }
 
+rmd_notebooks_escape_html <- function(text) {
+  text <- as.character(text)
+  text <- gsub("&", "&amp;", text, fixed = TRUE)
+  text <- gsub("<", "&lt;", text, fixed = TRUE)
+  text <- gsub(">", "&gt;", text, fixed = TRUE)
+  text
+}
+
+rmd_notebooks_format_rows <- function(display) {
+  column_count <- length(display)
+  formatted <- lapply(seq_len(column_count), function(index) {
+    column <- display[[index]]
+    rendered <- format(column, trim = TRUE, justify = "left")
+    rendered[is.na(column)] <- "NA"
+    rmd_notebooks_escape_html(rendered)
+  })
+  row_labels <- rmd_notebooks_escape_html(rownames(display))
+  row_count <- nrow(display)
+
+  vapply(seq_len(row_count), function(row_index) {
+    cells <- vapply(formatted, function(column) column[row_index], character(1))
+    sprintf(
+      "<tr><th>%s</th>%s</tr>",
+      if (length(row_labels) >= row_index) row_labels[row_index] else "",
+      paste0("<td>", cells, "</td>", collapse = "")
+    )
+  }, character(1))
+}
+
+rmd_notebooks_data_frame_to_html <- function(df, max_rows) {
+  total_rows <- nrow(df)
+  total_cols <- ncol(df)
+  # Replicate pandas: show every row up to max_rows; once exceeded, collapse to the
+  # first and last rows (min_rows, capped at max_rows) with an ellipsis row between.
+  truncated <- is.finite(max_rows) && max_rows > 0 && total_rows > max_rows
+
+  body_rows <- character()
+  if (truncated) {
+    shown <- min(10L, as.integer(max_rows))
+    head_count <- as.integer(ceiling(shown / 2))
+    tail_count <- shown - head_count
+    head_rows <- rmd_notebooks_format_rows(head(df, head_count))
+    ellipsis <- sprintf(
+      "<tr class=\"rmd-df-ellipsis\"><th>...</th>%s</tr>",
+      paste(rep("<td>...</td>", total_cols), collapse = "")
+    )
+    body_rows <- c(head_rows, ellipsis)
+    if (tail_count > 0) {
+      body_rows <- c(body_rows, rmd_notebooks_format_rows(tail(df, tail_count)))
+    }
+  } else {
+    body_rows <- rmd_notebooks_format_rows(df)
+  }
+
+  header_cells <- paste0("<th>", rmd_notebooks_escape_html(names(df)), "</th>", collapse = "")
+  thead <- sprintf("<thead><tr><th></th>%s</tr></thead>", header_cells)
+  tbody <- sprintf("<tbody>%s</tbody>", paste(body_rows, collapse = ""))
+
+  # pandas only prints the dimensions line when the frame is truncated.
+  meta <- if (truncated) {
+    sprintf("<p class=\"rmd-df-meta\">%d rows &times; %d columns</p>", total_rows, total_cols)
+  } else {
+    ""
+  }
+
+  style <- paste(
+    ".rmd-df{color:var(--vscode-editor-foreground,var(--vscode-foreground));font-family:var(--vscode-font-family);font-size:var(--vscode-font-size,13px);padding:4px 0;max-width:100%;overflow-x:auto;}",
+    ".rmd-df table.dataframe{border-collapse:collapse;border:none;}",
+    ".rmd-df table.dataframe th,.rmd-df table.dataframe td{padding:0.3em 0.8em;text-align:right;white-space:nowrap;border:none;vertical-align:middle;}",
+    ".rmd-df table.dataframe thead th{font-weight:bold;background:var(--vscode-keybindingTable-headerBackground,var(--vscode-editorWidget-background));border-bottom:1px solid var(--vscode-editorWidget-border,var(--vscode-panel-border));}",
+    ".rmd-df table.dataframe tbody th{font-weight:bold;color:var(--vscode-descriptionForeground);}",
+    ".rmd-df table.dataframe tbody tr:nth-child(even){background:var(--vscode-list-hoverBackground);}",
+    ".rmd-df table.dataframe tbody tr:hover{background:var(--vscode-list-inactiveSelectionBackground);}",
+    ".rmd-df .rmd-df-meta{color:var(--vscode-descriptionForeground);font-size:0.9em;margin:6px 0 0;}",
+    sep = ""
+  )
+
+  sprintf(
+    "<div class=\"rmd-df\"><style>%s</style><table class=\"dataframe\">%s%s</table>%s</div>",
+    style,
+    thead,
+    tbody,
+    meta
+  )
+}
+
 rmd_notebooks_collect_plot_paths <- function(directory, started_at) {
   pattern <- sprintf("^plot-%s-.*\\.png$", started_at)
   if (!dir.exists(directory)) {
@@ -284,7 +370,7 @@ rmd_notebooks_update_vscode_r_workspace <- function() {
   })
 }
 
-rmd_notebooks_execute <- function(code, working_directory, artifact_directory, plot_width_in, plot_height_in, plot_dpi) {
+rmd_notebooks_execute <- function(code, working_directory, artifact_directory, plot_width_in, plot_height_in, plot_dpi, df_render, df_max_rows) {
   if (nzchar(working_directory) && dir.exists(working_directory)) {
     setwd(working_directory)
   }
@@ -325,6 +411,9 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
         result <- withVisible(eval(expression, envir = user_env))
         if (result$visible && !is.null(result$value)) {
           html_output <- rmd_notebooks_render_html(result$value)
+          if (is.null(html_output) && isTRUE(df_render) && is.data.frame(result$value)) {
+            html_output <- rmd_notebooks_data_frame_to_html(result$value, df_max_rows)
+          }
           if (!is.null(html_output)) {
             html_buffer <- c(html_buffer, html_output)
           } else {
@@ -398,6 +487,8 @@ repeat {
   plot_width_in <- readLines(con = stdin(), n = 1, warn = FALSE)
   plot_height_in <- readLines(con = stdin(), n = 1, warn = FALSE)
   plot_dpi <- readLines(con = stdin(), n = 1, warn = FALSE)
+  df_render_line <- readLines(con = stdin(), n = 1, warn = FALSE)
+  df_max_rows_line <- readLines(con = stdin(), n = 1, warn = FALSE)
   code_count_line <- readLines(con = stdin(), n = 1, warn = FALSE)
 
   working_directory <- sub("^WORKDIR:", "", working_directory)
@@ -405,6 +496,11 @@ repeat {
   plot_width_in <- sub("^PLOT_WIDTH:", "", plot_width_in)
   plot_height_in <- sub("^PLOT_HEIGHT:", "", plot_height_in)
   plot_dpi <- sub("^PLOT_DPI:", "", plot_dpi)
+  df_render <- !identical(sub("^DF_RENDER:", "", df_render_line), "0")
+  df_max_rows <- suppressWarnings(as.numeric(sub("^DF_MAX_ROWS:", "", df_max_rows_line)))
+  if (!is.finite(df_max_rows) || df_max_rows < 1) {
+    df_max_rows <- 50
+  }
   code_count <- suppressWarnings(as.integer(sub("^CODE_COUNT:", "", code_count_line)))
   if (!is.finite(code_count) || code_count < 0) {
     code_count <- 0L
@@ -432,7 +528,9 @@ repeat {
     rmd_notebooks_decode_line(artifact_directory),
     suppressWarnings(as.numeric(plot_width_in)),
     suppressWarnings(as.numeric(plot_height_in)),
-    suppressWarnings(as.numeric(plot_dpi))
+    suppressWarnings(as.numeric(plot_dpi)),
+    df_render,
+    df_max_rows
   )
 
   cat("RMD_NOTEBOOKS_RESULT_START\n")

--- a/package.json
+++ b/package.json
@@ -211,10 +211,16 @@
           "description": "Render data frames as HTML tables (like Jupyter) instead of plain text."
         },
         "rmdNotebooks.output.dataFrameMaxRows": {
-          "type": "number",
+          "type": "integer",
           "default": 50,
           "minimum": 1,
           "description": "Row threshold for rendered data frames. Frames with more rows are collapsed to the first and last rows with an ellipsis in between, like Jupyter."
+        },
+        "rmdNotebooks.output.dataFrameMaxColumns": {
+          "type": "integer",
+          "default": 50,
+          "minimum": 1,
+          "description": "Column threshold for rendered data frames. Frames with more columns are collapsed to the first and last columns with an ellipsis in between, like Jupyter."
         },
         "rmdNotebooks.output.revealMode": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,17 @@
           "minimum": 120,
           "description": "Maximum height in pixels for inline plot previews before viewport scaling is applied."
         },
+        "rmdNotebooks.output.dataFrameRender": {
+          "type": "boolean",
+          "default": true,
+          "description": "Render data frames as HTML tables (like Jupyter) instead of plain text."
+        },
+        "rmdNotebooks.output.dataFrameMaxRows": {
+          "type": "number",
+          "default": 50,
+          "minimum": 1,
+          "description": "Row threshold for rendered data frames. Frames with more rows are collapsed to the first and last rows with an ellipsis in between, like Jupyter."
+        },
         "rmdNotebooks.output.revealMode": {
           "type": "string",
           "enum": [

--- a/scripts/smoke_vscode_r_session_watcher.R
+++ b/scripts/smoke_vscode_r_session_watcher.R
@@ -27,12 +27,15 @@ encode <- function(value) {
 
 protocol_command <- function(code) {
   c(
-    "RMD_NOTEBOOKS_COMMAND_V1",
+    "RMD_NOTEBOOKS_COMMAND_V2",
     paste0("WORKDIR:", encode(repo_root)),
     paste0("ARTIFACT_DIR:", encode(artifact_dir)),
     "PLOT_WIDTH:",
     "PLOT_HEIGHT:",
     "PLOT_DPI:",
+    "DF_RENDER:1",
+    "DF_MAX_ROWS:50",
+    "DF_MAX_COLUMNS:50",
     paste0("CODE_COUNT:", length(code)),
     paste0("LINE:", vapply(code, encode, character(1), USE.NAMES = FALSE)),
     "RMD_NOTEBOOKS_END"

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -22,7 +22,7 @@ const PROMPT_START_MARKER = "RMD_NOTEBOOKS_PROMPT_START";
 const PROMPT_END_MARKER = "RMD_NOTEBOOKS_PROMPT_END";
 const PROMPT_RESPONSE_START_MARKER = "RMD_NOTEBOOKS_PROMPT_RESPONSE_START";
 const PROMPT_RESPONSE_END_MARKER = "RMD_NOTEBOOKS_PROMPT_RESPONSE_END";
-const COMMAND_MARKER = "RMD_NOTEBOOKS_COMMAND_V1";
+const COMMAND_MARKER = "RMD_NOTEBOOKS_COMMAND_V2";
 const COMMAND_END_MARKER = "RMD_NOTEBOOKS_END";
 
 interface RawExecutionPayload {
@@ -38,6 +38,7 @@ interface RawExecutionPayload {
 interface DataFrameRenderOptions {
   render: boolean;
   maxRows: number;
+  maxColumns: number;
 }
 
 interface PendingExecution {
@@ -85,7 +86,8 @@ export class RExecutor implements Executor {
     const timeoutMs = configuration.get<number>("execution.interactiveFallbackTimeoutMs", 0);
     const dataFrame: DataFrameRenderOptions = {
       render: configuration.get<boolean>("output.dataFrameRender", true),
-      maxRows: configuration.get<number>("output.dataFrameMaxRows", 50)
+      maxRows: configuration.get<number>("output.dataFrameMaxRows", 50),
+      maxColumns: configuration.get<number>("output.dataFrameMaxColumns", 50)
     };
     const payload = await session.execute(
       context.code,
@@ -408,6 +410,7 @@ class RSession {
     this.process.stdin.write(`PLOT_DPI:${request.plot?.dpi ?? ""}\n`);
     this.process.stdin.write(`DF_RENDER:${request.dataFrame?.render === false ? "0" : "1"}\n`);
     this.process.stdin.write(`DF_MAX_ROWS:${request.dataFrame?.maxRows ?? ""}\n`);
+    this.process.stdin.write(`DF_MAX_COLUMNS:${request.dataFrame?.maxColumns ?? ""}\n`);
     const codeLines = toProtocolLines(request.code);
     this.process.stdin.write(`CODE_COUNT:${codeLines.length}\n`);
     for (const line of codeLines) {

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -35,6 +35,11 @@ interface RawExecutionPayload {
   plots: string[];
 }
 
+interface DataFrameRenderOptions {
+  render: boolean;
+  maxRows: number;
+}
+
 interface PendingExecution {
   resolve: (payload: RawExecutionPayload) => void;
   reject: (error: Error) => void;
@@ -46,6 +51,7 @@ interface ExecutionRequest {
   workingDirectory?: string;
   artifactDirectory?: string;
   plot?: ExecutionContext["plot"];
+  dataFrame?: DataFrameRenderOptions;
   timeoutMs: number;
   promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>;
   onStart?: () => void;
@@ -75,12 +81,18 @@ export class RExecutor implements Executor {
 
   public async executeChunk(context: ExecutionContext): Promise<ExecutionResult> {
     const session = this.getOrCreateSession(context.documentUri, context.workspaceFolder);
-    const timeoutMs = vscode.workspace.getConfiguration("rmdNotebooks").get<number>("execution.interactiveFallbackTimeoutMs", 0);
+    const configuration = vscode.workspace.getConfiguration("rmdNotebooks");
+    const timeoutMs = configuration.get<number>("execution.interactiveFallbackTimeoutMs", 0);
+    const dataFrame: DataFrameRenderOptions = {
+      render: configuration.get<boolean>("output.dataFrameRender", true),
+      maxRows: configuration.get<number>("output.dataFrameMaxRows", 50)
+    };
     const payload = await session.execute(
       context.code,
       context.workspaceFolder,
       context.artifactDirectory,
       context.plot,
+      dataFrame,
       timeoutMs,
       context.prompt,
       context.onStart,
@@ -280,6 +292,7 @@ class RSession {
     workingDirectory?: string,
     artifactDirectory?: string,
     plot?: ExecutionContext["plot"],
+    dataFrame?: DataFrameRenderOptions,
     timeoutMs = 15000,
     promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>,
     onStart?: () => void,
@@ -289,7 +302,7 @@ class RSession {
     // running waits its turn and runs in order, like cells in a Jupyter notebook.
     return new Promise<RawExecutionPayload>((resolve, reject) => {
       const task: QueuedExecution = {
-        request: { code, workingDirectory, artifactDirectory, plot, timeoutMs, promptHandler, onStart },
+        request: { code, workingDirectory, artifactDirectory, plot, dataFrame, timeoutMs, promptHandler, onStart },
         resolve,
         reject
       };
@@ -393,6 +406,8 @@ class RSession {
     this.process.stdin.write(`PLOT_WIDTH:${request.plot?.widthInches ?? ""}\n`);
     this.process.stdin.write(`PLOT_HEIGHT:${request.plot?.heightInches ?? ""}\n`);
     this.process.stdin.write(`PLOT_DPI:${request.plot?.dpi ?? ""}\n`);
+    this.process.stdin.write(`DF_RENDER:${request.dataFrame?.render === false ? "0" : "1"}\n`);
+    this.process.stdin.write(`DF_MAX_ROWS:${request.dataFrame?.maxRows ?? ""}\n`);
     const codeLines = toProtocolLines(request.code);
     this.process.stdin.write(`CODE_COUNT:${codeLines.length}\n`);
     for (const line of codeLines) {

--- a/src/test/suite/rStartupArgs.test.ts
+++ b/src/test/suite/rStartupArgs.test.ts
@@ -65,6 +65,10 @@ describe("rStartupArgs", () => {
     assert.deepEqual(properties["rmdNotebooks.r.args"].default, [...DEFAULT_INLINE_R_ARGS]);
     assert.deepEqual(properties["rmdNotebooks.r.terminalArgs"].default, [...DEFAULT_TERMINAL_R_ARGS]);
     assert.equal(properties["rmdNotebooks.r.sourceVscodeRSessionWatcher"].default, true);
+    assert.equal(properties["rmdNotebooks.output.dataFrameMaxRows"].type, "integer");
+    assert.equal(properties["rmdNotebooks.output.dataFrameMaxRows"].default, 50);
+    assert.equal(properties["rmdNotebooks.output.dataFrameMaxColumns"].type, "integer");
+    assert.equal(properties["rmdNotebooks.output.dataFrameMaxColumns"].default, 50);
   });
 });
 

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -160,6 +160,73 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(state.outputs.some((record) => record.outputTypes.includes("html")));
   });
 
+  it("renders data frames as escaped HTML without losing matrix columns", async () => {
+    await writeFixture(
+      "data-frame-html.qmd",
+      [
+        "# Data frame HTML",
+        "",
+        "```{r frame}",
+        "data.frame(text = c('<b>&', 'plain'), matrix_values = I(matrix(1:4, nrow = 2)))",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("data-frame-html.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const codeCell = editor.notebook.cellAt(findFirstCodeCellIndex(editor.notebook));
+    const renderedCell = await waitForNotebookOutput(codeCell, (cell) =>
+      cell.outputs.some((output) => output.items.some((item) => item.mime === "text/html"))
+    );
+    const html = notebookOutputText(renderedCell, "text/html");
+
+    assert.ok(html.includes("&lt;b&gt;&amp;"), "Cell contents should be HTML-escaped.");
+    assert.ok(html.includes("matrix_values.1") && html.includes("matrix_values.2"), "Matrix columns should be expanded like normal R output.");
+    assert.match(html, /<td>3<\/td>[\s\S]*<td>4<\/td>/, "Expanded matrix-column values should not be dropped.");
+  });
+
+  it("truncates data-frame rows and columns and can restore plain-text output", async () => {
+    await writeFixture(
+      "data-frame-truncation.qmd",
+      [
+        "# Data frame truncation",
+        "",
+        "```{r frame}",
+        "data.frame(c1 = 1:6, c2 = 11:16, c3 = 21:26, c4 = 31:36, c5 = 41:46, c6 = 51:56)",
+        "```",
+        ""
+      ].join("\n")
+    );
+    await updateTestSetting("output.dataFrameMaxRows", 4);
+    await updateTestSetting("output.dataFrameMaxColumns", 4);
+
+    const editor = await openNotebookEditor("data-frame-truncation.qmd");
+    editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+
+    const codeCell = editor.notebook.cellAt(findFirstCodeCellIndex(editor.notebook));
+    const renderedCell = await waitForNotebookOutput(codeCell, (cell) =>
+      cell.outputs.some((output) => output.items.some((item) => item.mime === "text/html"))
+    );
+    const html = notebookOutputText(renderedCell, "text/html");
+    assert.ok(html.includes("6 rows &times; 6 columns"));
+    assert.ok(html.includes("<th>c1</th>") && html.includes("<th>c2</th>"));
+    assert.ok(html.includes("<th>c5</th>") && html.includes("<th>c6</th>"));
+    assert.ok(!html.includes("<th>c3</th>") && !html.includes("<th>c4</th>"));
+    assert.ok(html.includes("rmd-df-ellipsis"));
+
+    await updateTestSetting("output.dataFrameRender", false);
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+    const plainCell = await waitForNotebookOutput(codeCell, (cell) =>
+      cell.outputs.some((output) => output.items.some((item) => item.mime === "application/vnd.code.notebook.stdout")) &&
+      cell.outputs.every((output) => output.items.every((item) => item.mime !== "text/html"))
+    );
+    assert.ok(notebookOutputText(plainCell, "application/vnd.code.notebook.stdout").includes("c1"));
+  });
+
   it("evaluates inline chunks in the global environment without exposing protocol internals", async () => {
     await writeFixture(
       "global-env.qmd",
@@ -1458,6 +1525,9 @@ async function resetTestSettings(): Promise<void> {
   await updateTestSetting("r.startupTimeoutMs", undefined);
   await updateTestSetting("execution.interactiveFallbackTimeoutMs", 0);
   await updateTestSetting("execution.interactiveFallbackBehavior", "prompt");
+  await updateTestSetting("output.dataFrameRender", undefined);
+  await updateTestSetting("output.dataFrameMaxRows", undefined);
+  await updateTestSetting("output.dataFrameMaxColumns", undefined);
 }
 
 async function updateTestSetting(section: string, value: unknown): Promise<void> {
@@ -1497,6 +1567,14 @@ function findCodeCellIndex(notebook: vscode.NotebookDocument, snippet: string): 
 
 function singleCellRange(index: number): vscode.NotebookRange {
   return new vscode.NotebookRange(index, index + 1);
+}
+
+function notebookOutputText(cell: vscode.NotebookCell, mime: string): string {
+  return cell.outputs
+    .flatMap((output) => output.items)
+    .filter((item) => item.mime === mime)
+    .map((item) => Buffer.from(item.data).toString("utf8"))
+    .join("\n");
 }
 
 async function waitForNotebookOutput(


### PR DESCRIPTION
## Summary

Auto-printed `data.frame` / `tibble` / `data.table` values were dumped as plain
text. This renders them as an HTML table in the cell output, the way a
`pandas.DataFrame` shows in a Jupyter notebook: theme-aware colours, bold header
and index, zebra rows, and pandas-style truncation (first and last rows with an
ellipsis between them) for large frames.

## Minimal reproduction

A throwaway workspace outside the repo, `/tmp/df-render-test/`, with one file.

`/tmp/df-render-test/render-data-frame.Rmd`
````
## 1. Basic data.frame (styled table)

```{r}
mtcars
```

## 2. Truncation (100 rows -> first 5 ... last 5)

```{r}
data.frame(x = 1:100, y = round(runif(100), 3), grp = factor(rep(c("a", "b"), 50)))
```

## 3. HTML escaping + NA

```{r}
data.frame(
  text = c("<b>bold</b>", "a & b", "plain"),
  value = c(1.5, NA, 3.0),
  stringsAsFactors = FALSE
)
```

## 4. tibble (inherits from data.frame)

```{r}
if (requireNamespace("tibble", quietly = TRUE)) tibble::tibble(a = 1:3, b = letters[1:3])
```

## 5. Non-data.frame values still print as text

```{r}
1:10
list(one = 1, two = "x")
```
````

Steps: F5 to launch the Extension Development Host, open the `/tmp/df-render-test/` folder, open `render-data-frame.Rmd` as a notebook, and run the chunks.

Expected:
- `mtcars` (32 rows) renders as a full styled table (under the 50-row threshold, so no truncation).
- The 100-row frame collapses the same way (5 + ellipsis + 5).
- The escaping chunk shows `<b>bold</b>` and `a & b` literally, and `NA` for the missing value.
- The `tibble` renders as a table; the plain vector and list still print as text.

To get the old plain-text behaviour back, set `"rmdNotebooks.output.dataFrameRender": false`.

## Motivation / Design

The session script already had an HTML output path (htmltools / `shiny.tag`
objects flow into `html_buffer`, are emitted as an `HTML` section, and become a
`text/html` output item that VS Code renders with its built-in renderer). Data
frames were the gap: they fell through to `print()`.

- Detection and rendering happen in R (`rmd_notebooks_data_frame_to_html`), so the
  full frame never has to cross the protocol; only the resulting HTML does, reusing
  the existing pipeline. No new output type or custom notebook renderer is needed.
- The look targets the built-in `text/html` renderer (which strips scripts), so the
  table is static and styled with a scoped `<style>` block using `--vscode-*`
  variables to match the active theme, mirroring how pandas ships its own styles.
- Truncation follows pandas: show all rows up to a threshold, otherwise collapse to
  `min_rows` (<= 10) split head/tail with an ellipsis row. The dimensions line is
  shown only when truncated, as pandas does.
- Two settings travel to the session as new command-protocol lines
  (`DF_RENDER`, `DF_MAX_ROWS`), inserted between `PLOT_DPI` and `CODE_COUNT` on
  both the writer (`rExecutor`) and the reader (R loop).

## Changes

- `media/r/rmd_notebooks_session.R`: add `rmd_notebooks_escape_html`,
  `rmd_notebooks_format_rows`, and `rmd_notebooks_data_frame_to_html`; in the eval
  loop, render `is.data.frame` values to HTML when `df_render` is on; read the two
  new protocol lines and pass them to `rmd_notebooks_execute`.
- `src/execution/rExecutor.ts`: read `output.dataFrameRender` /
  `output.dataFrameMaxRows`, pass them through `execute`, and write the `DF_RENDER`
  / `DF_MAX_ROWS` protocol lines.
- `package.json`: add the `dataFrameRender` (boolean, default true) and
  `dataFrameMaxRows` (number, default 20) settings.

## Test plan

- [x] `npm run test:unit`: 33 tests pass (existing suite, no regressions).
- [x] `npm run test:vscode`: 27 integration tests pass.
- [x] HTML generation verified at the R level: truncation collapses a 100-row frame
  to 12 `<tr>` (header + 5 + ellipsis + 5), the dimensions line appears only when
  truncated, cells with `<b>` / `&` are escaped, and `NA` renders literally.
- [x] Rendered output checked visually in the dev host across light/dark themes
  (table colours follow the theme; truncation and escaping as above).



