### PR TITLE
fix: count cell executions per notebook, resetting on session restart

### DIFF
--- a/src/execution/executorTypes.ts
+++ b/src/execution/executorTypes.ts
@@ -48,7 +48,10 @@ export interface ExecutionContext {
   prompt?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>;
   // Invoked when the chunk leaves the queue and actually begins running in the R
   // session, so the caller can flip the cell from "queued" to "running" only then.
-  onStart?: () => void;
+  // Receives this run's execution count: a per-session, 1-based number that lives on
+  // the R session, so it is scoped to the notebook and resets to 1 when the session
+  // restarts (the [1] [2] [3] badge VS Code shows next to each cell).
+  onStart?: (executionOrder: number) => void;
   // Cancels just this chunk: if it is still queued it is dropped from the queue; if
   // it is the one currently running it is interrupted. Other chunks are unaffected.
   token?: ExecutionCancellationToken;

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -48,7 +48,7 @@ interface ExecutionRequest {
   plot?: ExecutionContext["plot"];
   timeoutMs: number;
   promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>;
-  onStart?: () => void;
+  onStart?: (executionOrder: number) => void;
 }
 
 interface QueuedExecution {
@@ -193,6 +193,11 @@ class RSession {
   private sessionReady = false;
   private alive = true;
   private runtimeStderr = "";
+  // Per-session execution counter, mirroring a Jupyter kernel's execution_count: it
+  // counts the chunks this session has actually run, so it is scoped to the notebook
+  // (one session per document) and starts over at 1 whenever the session restarts,
+  // since a restart builds a brand-new RSession.
+  private executionCount = 0;
 
   public constructor(
     rPath: string,
@@ -282,7 +287,7 @@ class RSession {
     plot?: ExecutionContext["plot"],
     timeoutMs = 15000,
     promptHandler?: (request: InteractivePromptRequest) => Promise<InteractivePromptResponse>,
-    onStart?: () => void,
+    onStart?: (executionOrder: number) => void,
     token?: ExecutionCancellationToken
   ): Promise<RawExecutionPayload> {
     // Chunks are queued instead of rejected: a chunk requested while another is
@@ -384,8 +389,11 @@ class RSession {
     this.executionTimeoutMs = request.timeoutMs;
     this.runtimeStderr = "";
     // The chunk is leaving the queue now, so let the caller mark the cell as
-    // running (rather than queued) starting from this moment.
-    request.onStart?.();
+    // running (rather than queued) starting from this moment, tagged with this run's
+    // place in the session's execution count (the [N] badge). Only chunks that reach
+    // R increment it, so it advances in the order chunks actually execute.
+    this.executionCount += 1;
+    request.onStart?.(this.executionCount);
     this.armExecutionTimeout();
     this.process.stdin.write(`${COMMAND_MARKER}\n`);
     this.process.stdin.write(`WORKDIR:${encodeProtocolLine(request.workingDirectory ?? "")}\n`);

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -51,7 +51,6 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   private readonly runsToAbort = new Set<string>();
   private testPromptResponses: InteractivePromptResponse[] = [];
   private readonly testPromptRequests: InteractivePromptRequest[] = [];
-  private executionOrder = 0;
   private readonly controller: vscode.NotebookController;
 
   public constructor(
@@ -384,13 +383,17 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     // badge rather than a spinner, exactly like Run All. start() must precede end(),
     // so paths that never reach R still call this before ending the execution.
     let executionStarted = false;
-    const beginExecutionDisplay = (startTime?: number, assignOrder = true): void => {
+    // The execution order (the [N] badge) is the R session's own per-notebook count,
+    // delivered through onStart when the chunk actually starts running in R. Chunks
+    // that never reach R (eval=FALSE, no executor) leave it undefined and so show no
+    // number, the way a chunk that did not run has no count.
+    const beginExecutionDisplay = (startTime?: number, executionOrder?: number): void => {
       if (executionStarted) {
         return;
       }
       executionStarted = true;
-      if (assignOrder) {
-        execution.executionOrder = ++this.executionOrder;
+      if (executionOrder !== undefined) {
+        execution.executionOrder = executionOrder;
       }
       execution.start(startTime);
     };
@@ -442,7 +445,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         artifactDirectory: await this.outputStore.getArtifactDirectory(notebook.uri.toString()),
         plot: resolvePlotRenderOptions(chunkOptions),
         prompt: (request) => this.promptForChunkInput(notebook, cell, entry.chunk, request),
-        onStart: () => beginExecutionDisplay(Date.now()),
+        onStart: (executionOrder) => beginExecutionDisplay(Date.now(), executionOrder),
         token: execution.token
       });
       releaseAdmission();
@@ -483,7 +486,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         // ran. End the still-pending execution without assigning a run order or a
         // duration (start() must be called before end(), but with no start time so
         // no clock is shown), and clear it without flagging it as a failure.
-        beginExecutionDisplay(undefined, false);
+        beginExecutionDisplay(undefined);
         const cancelledRecord = createRecord(entry.chunk, "cancelled", []);
         outputs.set(entry.chunk.identity.chunkId, cancelledRecord);
         await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -567,6 +567,98 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(renderedCell.outputs.some((output) => output.items.some((item) => item.mime === "application/vnd.code.notebook.stderr")));
   });
 
+  it("counts executions per notebook, not across notebooks", async () => {
+    await writeFixture(
+      "exec-count-a.qmd",
+      [
+        "# Count A",
+        "",
+        "```{r a_one}",
+        "1 + 1",
+        "```",
+        "",
+        "```{r a_two}",
+        "2 + 2",
+        "```",
+        ""
+      ].join("\n")
+    );
+    await writeFixture(
+      "exec-count-b.qmd",
+      [
+        "# Count B",
+        "",
+        "```{r b_one}",
+        "3 + 3",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editorA = await openNotebookEditor("exec-count-a.qmd");
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+    await waitForDocumentState(editorA.notebook.uri, (candidate) =>
+      candidate.outputs.filter((record) => record.status === "success").length === 2
+    );
+    assert.equal(await waitForExecutionOrder(editorA.notebook.uri, findFirstCodeCellIndex(editorA.notebook)), 1);
+    assert.equal(await waitForExecutionOrder(editorA.notebook.uri, findLastCodeCellIndex(editorA.notebook)), 2);
+
+    const editorB = await openNotebookEditor("exec-count-b.qmd");
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+    await waitForDocumentState(editorB.notebook.uri, (candidate) =>
+      candidate.outputs.some((record) => record.status === "success")
+    );
+
+    // The bug this guards against: a single global counter kept climbing across
+    // notebooks, so B's first cell showed [3] (continuing from A's two runs). Each
+    // notebook has its own R session, so its count must start at [1].
+    const firstB = await waitForExecutionOrder(editorB.notebook.uri, findFirstCodeCellIndex(editorB.notebook));
+    assert.equal(firstB, 1, `Notebook B's first run should be [1], not a continuation of notebook A; got [${firstB}].`);
+  });
+
+  it("resets the execution count when the R session restarts", async () => {
+    await writeFixture(
+      "exec-count-reset.qmd",
+      [
+        "# Count reset",
+        "",
+        "```{r one}",
+        "1 + 1",
+        "```",
+        "",
+        "```{r two}",
+        "2 + 2",
+        "```",
+        ""
+      ].join("\n")
+    );
+
+    const editor = await openNotebookEditor("exec-count-reset.qmd");
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+    await waitForDocumentState(editor.notebook.uri, (candidate) =>
+      candidate.outputs.filter((record) => record.status === "success").length === 2
+    );
+    const lastCellIndex = findLastCodeCellIndex(editor.notebook);
+    assert.equal(await waitForExecutionOrder(editor.notebook.uri, findFirstCodeCellIndex(editor.notebook)), 1);
+    assert.equal(await waitForExecutionOrder(editor.notebook.uri, lastCellIndex), 2);
+
+    await vscode.commands.executeCommand("rmdNotebooks.restartSession");
+
+    // Re-run only the last cell. The counter lives on the R session, so a restart
+    // makes a fresh session that starts over: this run is [1], not [3]. Wait past the
+    // stale [2] still showing from before the restart so the assertion is meaningful.
+    editor.selection = singleCellRange(lastCellIndex);
+    await vscode.commands.executeCommand("rmdNotebooks.runCurrentChunk");
+    const resetOrder = await waitFor(() => {
+      const notebook = vscode.workspace.notebookDocuments.find(
+        (candidate) => candidate.uri.toString() === editor.notebook.uri.toString()
+      );
+      const order = notebook?.cellAt(lastCellIndex).executionSummary?.executionOrder;
+      return order === undefined || order === 2 ? undefined : order;
+    }, 15000);
+    assert.equal(resetOrder, 1, `Expected the execution count to reset to [1] after a restart, got [${resetOrder}].`);
+  });
+
   it("falls back to an R terminal when inline execution times out", async () => {
     await writeFixture(
       "interactive-timeout.qmd",
@@ -1541,6 +1633,17 @@ async function interruptRunningChunk(uri: vscode.Uri, chunkId: string): Promise<
   const record = state.outputs.find((entry) => entry.chunkId === chunkId);
   assert.equal(record?.status, "error", `Chunk ${chunkId} should be interrupted (status error), got ${record?.status}.`);
   await run.then(undefined, () => undefined);
+}
+
+async function waitForExecutionOrder(
+  uri: vscode.Uri,
+  cellIndex: number,
+  timeoutMs = 30000
+): Promise<number> {
+  return waitFor(() => {
+    const notebook = vscode.workspace.notebookDocuments.find((candidate) => candidate.uri.toString() === uri.toString());
+    return notebook?.cellAt(cellIndex).executionSummary?.executionOrder;
+  }, timeoutMs);
 }
 
 async function waitForCellTiming(


### PR DESCRIPTION
## Summary

The cell execution-order badge (the `[1] [2] [3]` counter VS Code shows next to each cell) was a single counter shared by every open notebook, so it kept climbing from one notebook into the next and never went back to `[1]` when the R session restarted. This scopes it to the R session, the way a Jupyter kernel's `execution_count` works: each notebook counts on its own and a restart starts over at `[1]`.

Fixes #15.

## Minimal reproduction

A throwaway workspace outside the repo, `/tmp/exec-count-test/`, with two files.

`/tmp/exec-count-test/notebook-a.Rmd`
````
---
title: "Notebook A"
---

```{r a_one}
1 + 1
```

```{r a_two}
2 + 2
```
````

`/tmp/exec-count-test/notebook-b.Rmd`
````
---
title: "Notebook B"
---

```{r b_one}
3 + 3
```

```{r b_two}
4 + 4
```
````

Steps: F5 to launch the Extension Development Host, open the `/tmp/exec-count-test/` folder, then:

1. Open `notebook-a.Rmd` as a notebook and Run All. Its cells show `[1]` and `[2]`.
2. Open `notebook-b.Rmd` and Run All.
3. Back in `notebook-a.Rmd`, run "Restart R Session", then re-run its first cell.

Before:
- Step 2: `notebook-b.Rmd`'s cells show `[3]` and `[4]`, continuing notebook A's count.
- Step 3: the re-run shows `[5]`, the global counter just keeps climbing.

After:
- Step 2: `notebook-b.Rmd`'s cells show `[1]` and `[2]`.
- Step 3: the re-run shows `[1]`, the fresh session starts the count over.

## Design / behavior note

The counter now lives on the `RSession` (one session per document), so:
- per-notebook falls out for free (each session counts independently), and
- it resets on every restart for free, since a restart builds a brand-new `RSession` whose count starts at 0. No reset bookkeeping to keep in sync.

The number reaches the cell through the existing `onStart` callback, which now carries it.

One deliberate consequence worth flagging: chunks that never reach R no longer get a number. `eval=FALSE` (skipped) chunks and the defensive "no executor" branch previously consumed a slot in the global counter; now they show no badge, the way an unrun cell has no count, which matches knitr (an unevaluated chunk has no execution count). Happy to keep numbering them if you'd rather, but it would mean a second counter and non-monotonic numbers.

## Changes

- `src/execution/rExecutor.ts`: add a per-session `executionCount` to `RSession`, bump it in `beginExecution` when a chunk actually starts running in R, and pass it to `onStart`.
- `src/execution/executorTypes.ts`: `onStart` now carries the execution order (`(executionOrder: number) => void`).
- `src/notebook/notebookRuntime.ts`: drop the global `executionOrder` field; set `execution.executionOrder` from the value `onStart` delivers, leaving it unset for chunks that never run in R.

## Test plan

- [x] `npm run test:unit`: 33 tests pass.
- [x] `npm run test:vscode`: 35 tests pass, including two new ones.
- [x] New "counts executions per notebook, not across notebooks": a second notebook's first run is `[1]`, not a continuation of the first. Fails against the old global counter (it was `[3]`).
- [x] New "resets the execution count when the R session restarts": after a "Restart R Session", the next run is `[1]`, not `[3]`.

## Notes

I split this into a fix commit + a test commit to match how you collapsed #13 into feature + test on merge. Squash or reword however suits your history.
