### PR TITLE
[codex] Prepare 0.4.1 Positron/Open VSX compatibility release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
       - run: npm ci
       - run: npm run release:verify-version
       - run: npm run test:unit
-      - run: npm run package:vsix
+      - run: npm run package:vsix:marketplace
+      - run: npm run package:vsix:openvsx
 
       - uses: actions/upload-artifact@v4
         with:
@@ -54,7 +55,7 @@ jobs:
 
       - name: Publish to VS Code Marketplace
         if: github.event_name == 'release' || inputs.publish_marketplace
-        run: npm run deploy
+        run: npx vsce publish --packagePath *-marketplace.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
@@ -66,6 +67,6 @@ jobs:
 
       - name: Publish to Open VSX
         if: github.event_name == 'release' || inputs.publish_openvsx
-        run: npm run deploy:openvsx -- -p "$OVSX_PAT"
+        run: npx ovsx publish *-openvsx.vsix -p "$OVSX_PAT"
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,4 +21,5 @@ azure-pipelines.yml
 scripts/**
 out/test/**
 out/src/test/**
+out/package.json
 .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1
+
+- publish separate VS Code Marketplace and Open VSX VSIX variants so VS Code keeps the vscode-R dependency while Positron and other Open VSX hosts do not install an incompatible R extension (#17)
+- show a one-time vscode-R recommendation in compatible non-Positron hosts when the optional workspace-viewer integration is missing
+- mark Rmd Notebooks as the default editor for `.qmd` and `.Rmd` files so VS Code-compatible hosts open them as notebooks by default
+
 ## 0.4.0
 
 - queue inline R chunk requests in execution order, show waiting cells as pending, and support cancelling one cell without dropping the rest of the queue

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ Rmd Notebooks opens R Markdown and Quarto documents as runnable notebooks withou
 
 ## Requirements
 
-- VS Code `^1.88.0`
+- VS Code-compatible editor API `^1.88.0`
 - R available on your PATH, or configured with `rmdNotebooks.r.path`
-- The [vscode-R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), installed automatically as an extension dependency
 
-The vscode-R dependency is used for normal R tooling integration, including the R workspace viewer. Inline sessions can source vscode-R's session watcher so variables created in notebook chunks appear in the R sidebar.
+The VS Code Marketplace package installs the [vscode-R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) automatically for normal R tooling integration, including the R workspace viewer. The Open VSX package keeps vscode-R optional so Positron and other VS Code-compatible editors that provide their own R support can install Rmd Notebooks without an incompatible dependency.
 
 ## What It Does
 
@@ -52,7 +51,7 @@ The vscode-R dependency is used for normal R tooling integration, including the 
 
 ## Workspace Viewer
 
-Inline R sessions integrate with vscode-R's workspace watcher when `~/.vscode-R/init.R` is available. With the default settings, variables created from notebook chunks should appear under the R sidebar's Global Environment section.
+Inline R sessions integrate with vscode-R's workspace watcher when `~/.vscode-R/init.R` is available. In VS Code this is set up by the vscode-R extension. In Open VSX-based editors other than Positron, Rmd Notebooks may show a one-time prompt to install vscode-R if it is missing. Positron users should rely on Positron's built-in R support instead.
 
 You can verify the integration from a notebook cell:
 
@@ -80,7 +79,7 @@ If you do not want inline sessions to source vscode-R's watcher, disable:
 - Only a subset of knitr options is enforced today: `eval=FALSE`, `include=FALSE`, `results='hide'`, `fig.width`, `fig.height`, `fig.asp`, and `dpi`
 - `echo`, `warning`, and `message` are parsed but not fully enforced
 - Unsupported interactive flows can fall back to an R terminal only when `rmdNotebooks.execution.interactiveFallbackTimeoutMs` is enabled
-- vscode-R workspace integration depends on vscode-R's current session watcher internals
+- vscode-R workspace integration is optional on Open VSX builds and depends on vscode-R's current session watcher internals
 
 ## Commands
 
@@ -102,7 +101,7 @@ The notebook toolbar also exposes `Stop All Running Chunks`, `Restart R Session`
 - `rmdNotebooks.r.path`: path to the R executable. Defaults to `R`.
 - `rmdNotebooks.r.args`: arguments for inline chunk-execution R sessions. Defaults to `["--slave"]`.
 - `rmdNotebooks.r.terminalArgs`: arguments for the interactive R terminal. Defaults to `["--vanilla"]`.
-- `rmdNotebooks.r.sourceVscodeRSessionWatcher`: source `~/.vscode-R/init.R` in inline R sessions when present. Defaults to `true`.
+- `rmdNotebooks.r.sourceVscodeRSessionWatcher`: source `~/.vscode-R/init.R` in inline R sessions when present. Defaults to `true`; no-ops when vscode-R is not installed.
 - `rmdNotebooks.r.startupTimeoutMs`: time allowed for an inline R session to start. Defaults to `30000` milliseconds.
 - `rmdNotebooks.execution.interactiveFallbackTimeoutMs`: timeout for treating a stalled inline chunk as unsupported interactive input. Defaults to `0`, which disables the timeout.
 - `rmdNotebooks.execution.interactiveFallbackBehavior`: what to do when the optional interactive fallback timeout fires. Defaults to `prompt`.
@@ -143,6 +142,15 @@ npm run smoke:vscode-r
 ```
 
 This starts the inline R protocol with the vscode-R watcher enabled and verifies that variables created by a piped inline chunk appear in vscode-R's `workspace.json`.
+
+Release packaging produces two VSIX variants:
+
+```bash
+npm run package:vsix:marketplace
+npm run package:vsix:openvsx
+```
+
+The Marketplace variant keeps the hard vscode-R dependency. The Open VSX variant removes that dependency and uses an optional in-app recommendation for compatible non-Positron hosts.
 
 To create a shareable test build from the current branch, run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmd-notebooks-vscode",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmd-notebooks-vscode",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rmd-notebooks-vscode",
   "displayName": "Rmd Notebooks for VS Code",
   "description": "Open .Rmd and .qmd files as runnable R notebooks in VS Code and Positron.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "AlFontal",
   "author": "Alejandro Fontal",
   "license": "MIT",
@@ -43,6 +43,7 @@
       {
         "type": "rmd-notebooks-vscode-notebook",
         "displayName": "Rmd Notebooks",
+        "priority": "default",
         "selector": [
           {
             "filenamePattern": "*.qmd"
@@ -245,7 +246,9 @@
     "deploy:openvsx": "ovsx publish",
     "deploy:manual": "npm run publish:precheck && npm run deploy",
     "deploy:manual:all": "npm run publish:precheck && npm run deploy && npm run deploy:openvsx",
-    "package:vsix": "vsce package",
+    "package:vsix": "npm run package:vsix:marketplace",
+    "package:vsix:marketplace": "node scripts/package_variant_vsix.cjs marketplace",
+    "package:vsix:openvsx": "node scripts/package_variant_vsix.cjs openvsx",
     "package:vsix:test": "node scripts/package_test_vsix.cjs",
     "publish:precheck": "npm run test && npm run package:vsix",
     "release:verify-version": "node scripts/verify_release_version.cjs",

--- a/scripts/package_test_vsix.cjs
+++ b/scripts/package_test_vsix.cjs
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require("node:child_process");
-const fs = require("node:fs");
 const path = require("node:path");
-
-const packageJson = require("../package.json");
 
 function git(args, fallback) {
   try {
@@ -28,11 +25,12 @@ function slug(value) {
 const branch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || git(["branch", "--show-current"], "local");
 const sha = (process.env.GITHUB_SHA || git(["rev-parse", "--short", "HEAD"], "unknown")).slice(0, 12);
 const suffix = slug(process.argv[2] || `${branch}-${sha}`);
-const outputFile = `${packageJson.name}-${packageJson.version}-${suffix}.vsix`;
 
-fs.rmSync(outputFile, { force: true });
-execFileSync(process.platform === "win32" ? "npx.cmd" : "npx", ["vsce", "package", "--out", outputFile], {
-  stdio: "inherit"
-});
+for (const variant of ["marketplace", "openvsx"]) {
+  execFileSync(process.execPath, [path.join(__dirname, "package_variant_vsix.cjs"), variant, suffix], {
+    cwd: path.resolve(__dirname, ".."),
+    stdio: "inherit"
+  });
+}
 
-console.log(`Packaged test VSIX: ${path.resolve(outputFile)}`);
+console.log("Packaged test VSIX variants.");

--- a/scripts/package_variant_vsix.cjs
+++ b/scripts/package_variant_vsix.cjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const packagePath = path.join(root, "package.json");
+const originalPackageText = fs.readFileSync(packagePath, "utf8");
+const packageJson = JSON.parse(originalPackageText);
+const variant = process.argv[2] || "marketplace";
+const suffix = process.argv[3];
+
+if (!["marketplace", "openvsx"].includes(variant)) {
+  throw new Error(`Unknown VSIX variant: ${variant}`);
+}
+
+function outputName() {
+  return [
+    packageJson.name,
+    packageJson.version,
+    variant,
+    suffix
+  ].filter(Boolean).join("-") + ".vsix";
+}
+
+function npxBin() {
+  return process.platform === "win32" ? "npx.cmd" : "npx";
+}
+
+function readPackagedManifest(vsixPath) {
+  const raw = execFileSync("unzip", ["-p", vsixPath, "extension/package.json"], {
+    cwd: root,
+    encoding: "utf8"
+  });
+  return JSON.parse(raw);
+}
+
+function assertDependencyPolicy(vsixPath) {
+  const manifest = readPackagedManifest(vsixPath);
+  const dependencies = manifest.extensionDependencies || [];
+  const hasRExtensionDependency = dependencies.includes("REditorSupport.r");
+
+  if (variant === "marketplace" && !hasRExtensionDependency) {
+    throw new Error("Marketplace VSIX must keep extensionDependencies: REditorSupport.r");
+  }
+
+  if (variant === "openvsx" && hasRExtensionDependency) {
+    throw new Error("Open VSX VSIX must not hard-depend on REditorSupport.r");
+  }
+}
+
+const outputFile = outputName();
+const outputPath = path.join(root, outputFile);
+const manifest = JSON.parse(originalPackageText);
+
+if (variant === "openvsx") {
+  delete manifest.extensionDependencies;
+}
+
+fs.rmSync(outputPath, { force: true });
+
+try {
+  if (variant === "openvsx") {
+    fs.writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+
+  execFileSync(npxBin(), ["vsce", "package", "--out", outputFile], {
+    cwd: root,
+    stdio: "inherit"
+  });
+} finally {
+  fs.writeFileSync(packagePath, originalPackageText);
+}
+
+assertDependencyPolicy(outputPath);
+console.log(`Packaged ${variant} VSIX: ${outputPath}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { OutputChannelController } from "./editor/outputChannelController";
 import { ExecutorRegistry } from "./execution/executorRegistry";
 import { RExecutor } from "./execution/rExecutor";
 import { RTerminalRunner } from "./execution/rTerminalRunner";
+import { maybeRecommendRExtension } from "./integration/rExtensionRecommendation";
 import { InlineChunksCellStatusBarProvider } from "./notebook/cellStatusBarProvider";
 import { InlineChunksNotebookRuntime } from "./notebook/notebookRuntime";
 import { InlineChunksNotebookSerializer } from "./notebook/notebookSerializer";
@@ -66,6 +67,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Inline
   );
 
   await notebookRuntime.initialize();
+  const recommendationTimer = setTimeout(() => void maybeRecommendRExtension(context), 2000);
+  context.subscriptions.push(new vscode.Disposable(() => clearTimeout(recommendationTimer)));
 
   return {
     getDocumentState: async (documentUri: string) => notebookRuntime.getDocumentState(documentUri),

--- a/src/integration/rExtensionRecommendation.ts
+++ b/src/integration/rExtensionRecommendation.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import {
+  R_EXTENSION_ID,
+  R_EXTENSION_RECOMMENDATION_STATE_KEY,
+  RExtensionRecommendationState,
+  shouldRecommendRExtension,
+} from "./rExtensionRecommendationState";
+
+const INSTALL = "Install";
+const NOT_NOW = "Not now";
+const DONT_ASK_AGAIN = "Don't ask again";
+
+export async function maybeRecommendRExtension(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const state = context.globalState.get<RExtensionRecommendationState>(
+    R_EXTENSION_RECOMMENDATION_STATE_KEY,
+  );
+  const isInstalled =
+    vscode.extensions.getExtension(R_EXTENSION_ID) !== undefined;
+
+  if (!shouldRecommendRExtension(vscode.env, isInstalled, state)) {
+    return;
+  }
+
+  const selection = await vscode.window.showInformationMessage(
+    "Rmd Notebooks: install the R extension for VS Code workspace viewer integration.",
+    INSTALL,
+    NOT_NOW,
+    DONT_ASK_AGAIN,
+  );
+
+  if (selection === INSTALL) {
+    await context.globalState.update(
+      R_EXTENSION_RECOMMENDATION_STATE_KEY,
+      "installed",
+    );
+    try {
+      await vscode.commands.executeCommand(
+        "workbench.extensions.installExtension",
+        R_EXTENSION_ID,
+      );
+    } catch (error) {
+      await context.globalState.update(
+        R_EXTENSION_RECOMMENDATION_STATE_KEY,
+        undefined,
+      );
+      void vscode.window.showWarningMessage(
+        `Rmd Notebooks: could not install the R extension automatically. ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return;
+  }
+
+  await context.globalState.update(
+    R_EXTENSION_RECOMMENDATION_STATE_KEY,
+    selection === DONT_ASK_AGAIN ? "never" : "dismissed",
+  );
+}

--- a/src/integration/rExtensionRecommendationState.ts
+++ b/src/integration/rExtensionRecommendationState.ts
@@ -1,0 +1,21 @@
+export const R_EXTENSION_ID = "REditorSupport.r";
+export const R_EXTENSION_RECOMMENDATION_STATE_KEY = "rmdNotebooks.rExtensionRecommendationState";
+
+export type RExtensionRecommendationState = "installed" | "dismissed" | "never";
+
+export interface HostIdentity {
+  appName: string;
+  uriScheme: string;
+}
+
+export function isPositronHost(host: HostIdentity): boolean {
+  return `${host.appName} ${host.uriScheme}`.toLowerCase().includes("positron");
+}
+
+export function shouldRecommendRExtension(
+  host: HostIdentity,
+  isRExtensionInstalled: boolean,
+  state: RExtensionRecommendationState | undefined
+): boolean {
+  return !isRExtensionInstalled && !isPositronHost(host) && state === undefined;
+}

--- a/src/test/suite/packageManifest.test.ts
+++ b/src/test/suite/packageManifest.test.ts
@@ -1,0 +1,12 @@
+import { strict as assert } from "node:assert";
+import packageJson from "../../../package.json";
+
+describe("package manifest", () => {
+  it("keeps vscode-R as a Marketplace extension dependency", () => {
+    assert.ok(packageJson.extensionDependencies.includes("REditorSupport.r"));
+  });
+
+  it("makes Rmd Notebooks the default editor for contributed notebook files", () => {
+    assert.equal(packageJson.contributes.notebooks[0].priority, "default");
+  });
+});

--- a/src/test/suite/rExtensionRecommendationState.test.ts
+++ b/src/test/suite/rExtensionRecommendationState.test.ts
@@ -1,0 +1,23 @@
+import { strict as assert } from "node:assert";
+import {
+  isPositronHost,
+  shouldRecommendRExtension
+} from "../../../src/integration/rExtensionRecommendationState";
+
+describe("rExtensionRecommendationState", () => {
+  it("detects Positron hosts by app name or URI scheme", () => {
+    assert.equal(isPositronHost({ appName: "Positron", uriScheme: "vscode" }), true);
+    assert.equal(isPositronHost({ appName: "Code", uriScheme: "positron" }), true);
+    assert.equal(isPositronHost({ appName: "Visual Studio Code", uriScheme: "vscode" }), false);
+  });
+
+  it("recommends vscode-R only for non-Positron hosts without a stored choice", () => {
+    const host = { appName: "VSCodium", uriScheme: "vscode" };
+
+    assert.equal(shouldRecommendRExtension(host, false, undefined), true);
+    assert.equal(shouldRecommendRExtension(host, true, undefined), false);
+    assert.equal(shouldRecommendRExtension(host, false, "dismissed"), false);
+    assert.equal(shouldRecommendRExtension(host, false, "never"), false);
+    assert.equal(shouldRecommendRExtension({ appName: "Positron", uriScheme: "positron" }, false, undefined), false);
+  });
+});

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -102,6 +102,18 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(editor.notebook.getCells().some((cell) => cell.kind === vscode.NotebookCellKind.Code));
   });
 
+  it("opens qmd files as notebooks through the default editor path", async () => {
+    const uri = getWorkspaceFileUri("integration.qmd");
+
+    await vscode.commands.executeCommand("vscode.open", uri);
+    await waitFor(
+      () => vscode.window.activeNotebookEditor?.notebook.uri.toString() === uri.toString() ? true : undefined,
+      3000
+    );
+
+    assert.equal(vscode.window.activeNotebookEditor?.notebook.notebookType, "rmd-notebooks-vscode-notebook");
+  });
+
   it("runs the current qmd chunk and renders stdout inline", async () => {
     const editor = await openNotebookEditor("integration.qmd");
     editor.selection = singleCellRange(findFirstCodeCellIndex(editor.notebook));


### PR DESCRIPTION
## Summary

This prepares the 0.4.1 patch release for the Positron/Open VSX compatibility issue in #17.

- keep `REditorSupport.r` as a hard dependency for the VS Code Marketplace package
- generate a separate Open VSX VSIX variant that removes that hard dependency for Positron and other Open VSX hosts
- add a one-time vscode-R recommendation for compatible non-Positron hosts when vscode-R is missing
- mark the notebook contribution as the default editor for `.qmd`/`.Rmd` so VSCodium-style hosts open files as notebooks by default
- document the Marketplace/Open VSX split and add the 0.4.1 changelog entry

## Root Cause

`extensionDependencies` is static in the packaged extension manifest. Publishing the same manifest everywhere forced Open VSX consumers such as Positron to install `REditorSupport.r`, which Positron does not support because it ships its own R integration.

## Validation

- `npm run test:unit`
- `npm run test:vscode`
- `npm run package:vsix:test`
- manually tested the Open VSX VSIX in Positron and VSCodium during development
