### PR TITLE
fix: show YAML frontmatter as a notebook cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- show document frontmatter as an editable, syntax-highlighted YAML cell without making it executable (#19)
+
 ## 0.4.1
 
 - publish separate VS Code Marketplace and Open VSX VSIX variants so VS Code keeps the vscode-R dependency while Positron and other Open VSX hosts do not install an incompatible R extension (#17)

--- a/src/notebook/frontmatter.ts
+++ b/src/notebook/frontmatter.ts
@@ -1,0 +1,30 @@
+export interface ParsedFrontmatter {
+  openingFence: "---";
+  closingFence: "---" | "...";
+  body: string;
+  endLine: number;
+}
+
+export function parseFrontmatter(source: string): ParsedFrontmatter | undefined {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") {
+    return undefined;
+  }
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line !== "---" && line !== "...") {
+      continue;
+    }
+
+    return {
+      openingFence: "---",
+      closingFence: line,
+      body: lines.slice(1, index).join("\n"),
+      endLine: index
+    };
+  }
+
+  return undefined;
+}

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -369,7 +369,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   private async executeCell(notebook: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<ExecuteCellOutcome> {
-    if (cell.kind !== vscode.NotebookCellKind.Code) {
+    if (!isExecutableChunkCell(cell)) {
       return "completed";
     }
 
@@ -788,13 +788,13 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     for (let index = selection.start; index < selection.end; index += 1) {
       const cell = notebook.cellAt(index);
-      if (cell.kind === vscode.NotebookCellKind.Code) {
+      if (isExecutableChunkCell(cell)) {
         return { notebook, cell };
       }
     }
 
     const activeCell = notebook.cellAt(Math.min(selection.start, Math.max(notebook.cellCount - 1, 0)));
-    return activeCell.kind === vscode.NotebookCellKind.Code ? { notebook, cell: activeCell } : undefined;
+    return isExecutableChunkCell(activeCell) ? { notebook, cell: activeCell } : undefined;
   }
 
   private async ensureOutputsLoaded(documentUri: string): Promise<Map<string, ChunkOutputRecord>> {
@@ -945,7 +945,7 @@ function buildNotebookSnapshot(
 ): NotebookSnapshot {
   const codeCells = notebook
     .getCells()
-    .filter((cell) => cell.kind === vscode.NotebookCellKind.Code)
+    .filter(isExecutableChunkCell)
     .map((cell) => ({
       cell,
       index: cell.index,
@@ -985,6 +985,14 @@ function buildNotebookSnapshot(
     })),
     generatedAt: Date.now()
   };
+}
+
+function isExecutableChunkCell(cell: vscode.NotebookCell): boolean {
+  if (cell.kind !== vscode.NotebookCellKind.Code) {
+    return false;
+  }
+
+  return getInlineChunksMetadata(cell.metadata)?.kind !== "frontmatter";
 }
 
 function toParsedChunk(notebook: vscode.NotebookDocument, cell: vscode.NotebookCell): ParsedExecutableChunk {

--- a/src/notebook/notebookSource.ts
+++ b/src/notebook/notebookSource.ts
@@ -2,6 +2,7 @@ import { TextDecoder, TextEncoder } from "node:util";
 import * as vscode from "vscode";
 import { parseExecutableChunks } from "../document/chunkParser";
 import { parseChunkOptions } from "./chunkOptions";
+import { parseFrontmatter } from "./frontmatter";
 import { getInlineChunksMetadata, withInlineChunksMetadata } from "./notebookTypes";
 
 const DECODER = new TextDecoder();
@@ -13,7 +14,19 @@ export function deserializeNotebookSource(content: Uint8Array): vscode.NotebookD
   const lines = normalized.length === 0 ? [] : normalized.split("\n");
   const chunks = parseExecutableChunks("", normalized);
   const cells: vscode.NotebookCellData[] = [];
+  const frontmatter = parseFrontmatter(normalized);
   let cursor = 0;
+
+  if (frontmatter) {
+    const frontmatterCell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, frontmatter.body, "yaml");
+    frontmatterCell.metadata = withInlineChunksMetadata(frontmatterCell.metadata, {
+      kind: "frontmatter",
+      openingFence: frontmatter.openingFence,
+      closingFence: frontmatter.closingFence
+    });
+    cells.push(frontmatterCell);
+    cursor = frontmatter.endLine + 1;
+  }
 
   for (const chunk of chunks) {
     const before = lines.slice(cursor, chunk.startLine).join("\n");
@@ -47,6 +60,17 @@ export function serializeNotebookSource(data: vscode.NotebookData): Uint8Array {
   const blocks: string[] = [];
 
   for (const cell of data.cells) {
+    const metadata = getInlineChunksMetadata(cell.metadata ?? {});
+    if (metadata?.kind === "frontmatter") {
+      const body = normalizeMarkupSource(cell.value);
+      blocks.push(
+        body.length > 0
+          ? `${metadata.openingFence}\n${body}\n${metadata.closingFence}`
+          : `${metadata.openingFence}\n${metadata.closingFence}`
+      );
+      continue;
+    }
+
     if (cell.kind === vscode.NotebookCellKind.Markup) {
       const markup = normalizeMarkupSource(cell.value);
       if (markup.length > 0) {
@@ -55,7 +79,6 @@ export function serializeNotebookSource(data: vscode.NotebookData): Uint8Array {
       continue;
     }
 
-    const metadata = getInlineChunksMetadata(cell.metadata ?? {});
     const header = buildHeader(cell.languageId, metadata);
     const closingFence = "`".repeat(Math.max(3, metadata?.kind === "code" ? metadata.fenceLength : 3));
     const body = cell.value.replace(/\r\n/g, "\n").replace(/\n+$/g, "");

--- a/src/notebook/notebookTypes.ts
+++ b/src/notebook/notebookTypes.ts
@@ -18,7 +18,16 @@ export interface InlineChunksMarkupCellMetadata {
   kind: "markup";
 }
 
-export type InlineChunksCellMetadata = InlineChunksCodeCellMetadata | InlineChunksMarkupCellMetadata;
+export interface InlineChunksFrontmatterCellMetadata {
+  kind: "frontmatter";
+  openingFence: "---";
+  closingFence: "---" | "...";
+}
+
+export type InlineChunksCellMetadata =
+  | InlineChunksCodeCellMetadata
+  | InlineChunksMarkupCellMetadata
+  | InlineChunksFrontmatterCellMetadata;
 
 export interface InlineChunksCellMetadataEnvelope {
   rmdNotebooks?: InlineChunksCellMetadata;

--- a/src/test/suite/frontmatter.test.ts
+++ b/src/test/suite/frontmatter.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "mocha";
+import { parseFrontmatter } from "../../notebook/frontmatter";
+
+describe("frontmatter", () => {
+  it("parses frontmatter only at the start of a document", () => {
+    assert.deepEqual(parseFrontmatter("---\ntitle: Example\n---\n\nBody"), {
+      openingFence: "---",
+      closingFence: "---",
+      body: "title: Example",
+      endLine: 2
+    });
+    assert.equal(parseFrontmatter("# Heading\n\n---\ntitle: Not frontmatter\n---"), undefined);
+  });
+
+  it("preserves an alternate YAML closing delimiter", () => {
+    assert.deepEqual(parseFrontmatter("---\ntitle: Example\n...\n"), {
+      openingFence: "---",
+      closingFence: "...",
+      body: "title: Example",
+      endLine: 2
+    });
+  });
+
+  it("does not treat an unclosed opening delimiter as frontmatter", () => {
+    assert.equal(parseFrontmatter("---\ntitle: Example"), undefined);
+  });
+});

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -102,6 +102,32 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(editor.notebook.getCells().some((cell) => cell.kind === vscode.NotebookCellKind.Code));
   });
 
+  it("opens YAML frontmatter as a non-executable source-preserving cell", async () => {
+    const editor = await openNotebookEditor("integration.rmd");
+    const frontmatter = editor.notebook.cellAt(0);
+
+    assert.equal(frontmatter.kind, vscode.NotebookCellKind.Code);
+    assert.equal(frontmatter.document.languageId, "yaml");
+    assert.equal(frontmatter.document.getText(), 'title: "Integration"\noutput: html_document');
+    assert.equal(frontmatter.metadata?.rmdNotebooks?.kind, "frontmatter");
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(
+      frontmatter.document.uri,
+      new vscode.Range(new vscode.Position(0, 0), frontmatter.document.lineAt(0).range.end),
+      'title: "Updated integration"'
+    );
+    await vscode.workspace.applyEdit(edit);
+    assert.ok(await editor.notebook.save());
+
+    const saved = Buffer.from(await vscode.workspace.fs.readFile(editor.notebook.uri)).toString("utf8");
+    assert.ok(saved.startsWith('---\ntitle: "Updated integration"\noutput: html_document\n---'));
+
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+    const state = await waitForDocumentState(editor.notebook.uri, (candidate) => candidate.outputs.length === 3);
+    assert.equal(state.snapshot?.chunkIds.length, 3);
+  });
+
   it("opens qmd files as notebooks through the default editor path", async () => {
     const uri = getWorkspaceFileUri("integration.qmd");
 
@@ -1685,7 +1711,7 @@ function getWorkspaceFileUri(name: string): vscode.Uri {
 }
 
 function findFirstCodeCellIndex(notebook: vscode.NotebookDocument): number {
-  const index = notebook.getCells().findIndex((cell) => cell.kind === vscode.NotebookCellKind.Code);
+  const index = notebook.getCells().findIndex(isExecutableChunkCell);
   assert.ok(index >= 0, "A code cell should exist.");
   return index;
 }
@@ -1693,7 +1719,7 @@ function findFirstCodeCellIndex(notebook: vscode.NotebookDocument): number {
 function findLastCodeCellIndex(notebook: vscode.NotebookDocument): number {
   const cells = notebook.getCells();
   for (let index = cells.length - 1; index >= 0; index -= 1) {
-    if (cells[index].kind === vscode.NotebookCellKind.Code) {
+    if (isExecutableChunkCell(cells[index])) {
       return index;
     }
   }
@@ -1703,10 +1729,14 @@ function findLastCodeCellIndex(notebook: vscode.NotebookDocument): number {
 
 function findCodeCellIndex(notebook: vscode.NotebookDocument, snippet: string): number {
   const index = notebook.getCells().findIndex(
-    (cell) => cell.kind === vscode.NotebookCellKind.Code && cell.document.getText().includes(snippet)
+    (cell) => isExecutableChunkCell(cell) && cell.document.getText().includes(snippet)
   );
   assert.ok(index >= 0, `Expected a code cell containing ${snippet}.`);
   return index;
+}
+
+function isExecutableChunkCell(cell: vscode.NotebookCell): boolean {
+  return cell.kind === vscode.NotebookCellKind.Code && cell.metadata?.rmdNotebooks?.kind !== "frontmatter";
 }
 
 function singleCellRange(index: number): vscode.NotebookRange {


### PR DESCRIPTION
## What changed

- detect document-leading YAML frontmatter in `.Rmd` and `.qmd` files
- show the frontmatter body as an editable, syntax-highlighted YAML cell
- preserve `---` and `...` closing delimiters when serializing
- exclude frontmatter from chunk execution, identity, outputs, and R-session counts

## Why

Frontmatter was previously treated as ordinary Markdown, so the delimiter rendered as a horizontal rule and the YAML did not have an editable source-oriented representation.

## Validation

- `npm run test:unit` — 40 passing
- `npm run test:vscode` — 40 passing
- `npm run package:vsix:marketplace`
- `npm run package:vsix:openvsx`

Fixes #19

## Screenshots

Source:

<img width="633" height="351" alt="image" src="https://github.com/user-attachments/assets/44198590-4bca-4dc0-9b40-6cf70f9d28e5" />

Notebook view:

<img width="747" height="377" alt="image" src="https://github.com/user-attachments/assets/d32b8b90-4e97-4577-bdad-a70168f0fa07" />

