### PR TITLE
feat: preview notebook HTML from the toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - show document frontmatter as an editable, syntax-highlighted YAML cell without making it executable (#19)
 - evaluate native knitr and Quarto inline R expressions in rendered, source-preserving prose cells (#20)
+- add an HTML preview command for `.Rmd` and `.qmd` notebooks that delegates to vscode-R or Quarto (#21)
 
 ## 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The VS Code Marketplace package installs the [vscode-R extension](https://market
 - Marks outputs stale after code edits
 - Supports cancelling an individual running or queued cell, plus Stop All for the active notebook run
 - Supports notebook commands for run current chunk, run all chunks, restart session, clear outputs, and source view
+- Opens `.Rmd` HTML previews through vscode-R and `.qmd` previews through Quarto without leaving notebook view
 - Supports chunk-header editing from notebook mode
 - Handles common prompt-style interactions such as `menu()` and `readline()` with VS Code UI
 - Lets unsupported interactive chunks fall back to an R terminal when the optional timeout is enabled
@@ -93,6 +94,7 @@ If you do not want inline sessions to source vscode-R's watcher, disable:
 - `Rmd Notebooks: Restart R Session`
 - `Rmd Notebooks: Run Current Chunk in R Terminal`
 - `Rmd Notebooks: Show Output Panel`
+- `Rmd Notebooks: Preview HTML`
 - `Rmd Notebooks: Edit Chunk Header`
 - `Rmd Notebooks: Toggle Notebook / Raw Source View`
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,12 @@
         "title": "Rmd Notebooks: Show Output Panel"
       },
       {
+        "command": "rmdNotebooks.previewHtml",
+        "title": "Preview HTML",
+        "category": "Rmd Notebooks",
+        "icon": "$(preview)"
+      },
+      {
         "command": "rmdNotebooks.editChunkHeader",
         "title": "Rmd Notebooks: Edit Chunk Header"
       },
@@ -113,6 +119,16 @@
     ],
     "menus": {
       "notebook/toolbar": [
+        {
+          "command": "rmdNotebooks.previewHtml",
+          "when": "notebookType == rmd-notebooks-vscode-notebook && resourceExtname =~ /\\.[Rr]md$/",
+          "group": "navigation@96"
+        },
+        {
+          "command": "rmdNotebooks.previewHtml",
+          "when": "notebookType == rmd-notebooks-vscode-notebook && resourceExtname == .qmd && !rmdNotebooks.quartoExtensionInstalled",
+          "group": "navigation@96"
+        },
         {
           "command": "rmdNotebooks.interruptSession",
           "when": "notebookType == rmd-notebooks-vscode-notebook",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         },
         {
           "command": "rmdNotebooks.previewHtml",
-          "when": "notebookType == rmd-notebooks-vscode-notebook && resourceExtname == .qmd && !rmdNotebooks.quartoExtensionInstalled",
+          "when": "notebookType == rmd-notebooks-vscode-notebook && resourceExtname == .qmd",
           "group": "navigation@96"
         },
         {

--- a/src/commands/previewHtml.ts
+++ b/src/commands/previewHtml.ts
@@ -1,0 +1,128 @@
+import * as vscode from "vscode";
+import { INLINE_CHUNKS_NOTEBOOK_TYPE, isInlineChunksNotebook } from "../notebook/notebookTypes";
+
+const VSCODE_R_EXTENSION_ID = "REditorSupport.r";
+const VSCODE_R_PREVIEW_COMMAND = "r.rmarkdown.showPreviewToSide";
+const QUARTO_EXTENSION_ID = "quarto.quarto";
+const QUARTO_PREVIEW_COMMAND = "quarto.preview";
+
+export type PreviewResult = "previewed" | "cancelled" | "unsupported" | "missing";
+
+export interface PreviewRequest {
+  uri: vscode.Uri;
+  viewColumn?: vscode.ViewColumn;
+  save(): Thenable<boolean>;
+}
+
+export interface PreviewServices {
+  ensureIntegration(extensionId: string, commandId: string, displayName: string): Promise<boolean>;
+  executeCommand(commandId: string, ...args: unknown[]): Thenable<unknown>;
+  openRawSource(uri: vscode.Uri, viewColumn?: vscode.ViewColumn): Promise<void>;
+  restoreNotebook(uri: vscode.Uri, viewColumn?: vscode.ViewColumn): Promise<void>;
+  showWarning(message: string): Thenable<unknown>;
+}
+
+export async function previewActiveNotebookHtml(): Promise<PreviewResult> {
+  const editor = vscode.window.activeNotebookEditor;
+  if (!editor || !isInlineChunksNotebook(editor.notebook)) {
+    void vscode.window.showWarningMessage("Rmd Notebooks: open an .Rmd or .qmd notebook to preview it.");
+    return "unsupported";
+  }
+
+  return previewNotebookHtml(
+    {
+      uri: editor.notebook.uri,
+      viewColumn: editor.viewColumn,
+      save: () => editor.notebook.save()
+    },
+    createPreviewServices()
+  );
+}
+
+export async function previewNotebookHtml(request: PreviewRequest, services: PreviewServices): Promise<PreviewResult> {
+  const extension = request.uri.path.slice(request.uri.path.lastIndexOf(".")).toLowerCase();
+  if (extension !== ".rmd" && extension !== ".qmd") {
+    await services.showWarning("Rmd Notebooks: HTML preview is available for .Rmd and .qmd files.");
+    return "unsupported";
+  }
+
+  if (!(await request.save())) {
+    await services.showWarning("Rmd Notebooks: save the notebook before opening its HTML preview.");
+    return "cancelled";
+  }
+
+  if (extension === ".qmd") {
+    if (!(await services.ensureIntegration(QUARTO_EXTENSION_ID, QUARTO_PREVIEW_COMMAND, "Quarto"))) {
+      return "missing";
+    }
+    await services.executeCommand(QUARTO_PREVIEW_COMMAND);
+    return "previewed";
+  }
+
+  if (!(await services.ensureIntegration(VSCODE_R_EXTENSION_ID, VSCODE_R_PREVIEW_COMMAND, "vscode-R"))) {
+    return "missing";
+  }
+
+  try {
+    await services.openRawSource(request.uri, request.viewColumn);
+    await services.executeCommand(VSCODE_R_PREVIEW_COMMAND);
+    return "previewed";
+  } finally {
+    await services.restoreNotebook(request.uri, request.viewColumn);
+  }
+}
+
+export async function updatePreviewIntegrationContexts(): Promise<void> {
+  await vscode.commands.executeCommand(
+    "setContext",
+    "rmdNotebooks.quartoExtensionInstalled",
+    vscode.extensions.getExtension(QUARTO_EXTENSION_ID) !== undefined
+  );
+}
+
+function createPreviewServices(): PreviewServices {
+  return {
+    ensureIntegration: async (extensionId, commandId, displayName) => {
+      const extension = vscode.extensions.getExtension(extensionId);
+      if (!extension) {
+        const choice = await vscode.window.showWarningMessage(
+          `Rmd Notebooks: ${displayName} is required to preview this document.`,
+          `Find ${displayName}`
+        );
+        if (choice === `Find ${displayName}`) {
+          await vscode.commands.executeCommand("workbench.extensions.search", `@id:${extensionId}`);
+        }
+        return false;
+      }
+
+      if (!extension.isActive) {
+        await extension.activate();
+      }
+      const commands = await vscode.commands.getCommands(true);
+      if (!commands.includes(commandId)) {
+        void vscode.window.showWarningMessage(
+          `Rmd Notebooks: ${displayName} is installed but does not provide the expected preview command.`
+        );
+        return false;
+      }
+      return true;
+    },
+    executeCommand: (commandId, ...args) => vscode.commands.executeCommand(commandId, ...args),
+    openRawSource: async (uri, viewColumn) => {
+      const document = await vscode.workspace.openTextDocument(uri);
+      await vscode.window.showTextDocument(document, {
+        preview: false,
+        preserveFocus: false,
+        viewColumn
+      });
+    },
+    restoreNotebook: async (uri, viewColumn) => {
+      await vscode.commands.executeCommand("vscode.openWith", uri, INLINE_CHUNKS_NOTEBOOK_TYPE, {
+        preview: false,
+        preserveFocus: false,
+        viewColumn
+      });
+    },
+    showWarning: (message) => vscode.window.showWarningMessage(message)
+  };
+}

--- a/src/commands/previewHtml.ts
+++ b/src/commands/previewHtml.ts
@@ -72,14 +72,6 @@ export async function previewNotebookHtml(request: PreviewRequest, services: Pre
   }
 }
 
-export async function updatePreviewIntegrationContexts(): Promise<void> {
-  await vscode.commands.executeCommand(
-    "setContext",
-    "rmdNotebooks.quartoExtensionInstalled",
-    vscode.extensions.getExtension(QUARTO_EXTENSION_ID) !== undefined
-  );
-}
-
 function createPreviewServices(): PreviewServices {
   return {
     ensureIntegration: async (extensionId, commandId, displayName) => {

--- a/src/commands/previewHtml.ts
+++ b/src/commands/previewHtml.ts
@@ -55,8 +55,13 @@ export async function previewNotebookHtml(request: PreviewRequest, services: Pre
     if (!(await services.ensureIntegration(QUARTO_EXTENSION_ID, QUARTO_PREVIEW_COMMAND, "Quarto"))) {
       return "missing";
     }
-    await services.executeCommand(QUARTO_PREVIEW_COMMAND);
-    return "previewed";
+    try {
+      await services.openRawSource(request.uri, request.viewColumn);
+      await services.executeCommand(QUARTO_PREVIEW_COMMAND);
+      return "previewed";
+    } finally {
+      await services.restoreNotebook(request.uri, request.viewColumn);
+    }
   }
 
   if (!(await services.ensureIntegration(VSCODE_R_EXTENSION_ID, VSCODE_R_PREVIEW_COMMAND, "vscode-R"))) {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { InlineChunksNotebookRuntime } from "../notebook/notebookRuntime";
 import { serializeNotebookSource } from "../notebook/notebookSource";
 import { INLINE_CHUNKS_NOTEBOOK_TYPE, isInlineChunksNotebook } from "../notebook/notebookTypes";
+import { previewActiveNotebookHtml } from "./previewHtml";
 
 export function registerCommands(controller: InlineChunksNotebookRuntime): vscode.Disposable[] {
   return [
@@ -34,6 +35,9 @@ export function registerCommands(controller: InlineChunksNotebookRuntime): vscod
     }),
     vscode.commands.registerCommand("rmdNotebooks.showOutputChannel", () => {
       controller.showOutputChannel();
+    }),
+    vscode.commands.registerCommand("rmdNotebooks.previewHtml", async () => {
+      await previewActiveNotebookHtml();
     }),
     vscode.commands.registerCommand(
       "rmdNotebooks.editChunkHeader",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { registerCommands } from "./commands/registerCommands";
-import { updatePreviewIntegrationContexts } from "./commands/previewHtml";
 import { OutputChannelController } from "./editor/outputChannelController";
 import { ExecutorRegistry } from "./execution/executorRegistry";
 import { RExecutor } from "./execution/rExecutor";
@@ -64,11 +63,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Inline
     vscode.notebooks.registerNotebookCellStatusBarItemProvider(INLINE_CHUNKS_NOTEBOOK_TYPE, cellStatusBarProvider),
     notebookRuntime,
     ...registerCommands(notebookRuntime),
-    vscode.extensions.onDidChange(() => void updatePreviewIntegrationContexts()),
     new vscode.Disposable(() => void rExecutor.disposeAll())
   );
 
-  await updatePreviewIntegrationContexts();
   await notebookRuntime.initialize();
   const recommendationTimer = setTimeout(() => void maybeRecommendRExtension(context), 2000);
   context.subscriptions.push(new vscode.Disposable(() => clearTimeout(recommendationTimer)));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { registerCommands } from "./commands/registerCommands";
+import { updatePreviewIntegrationContexts } from "./commands/previewHtml";
 import { OutputChannelController } from "./editor/outputChannelController";
 import { ExecutorRegistry } from "./execution/executorRegistry";
 import { RExecutor } from "./execution/rExecutor";
@@ -63,9 +64,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Inline
     vscode.notebooks.registerNotebookCellStatusBarItemProvider(INLINE_CHUNKS_NOTEBOOK_TYPE, cellStatusBarProvider),
     notebookRuntime,
     ...registerCommands(notebookRuntime),
+    vscode.extensions.onDidChange(() => void updatePreviewIntegrationContexts()),
     new vscode.Disposable(() => void rExecutor.disposeAll())
   );
 
+  await updatePreviewIntegrationContexts();
   await notebookRuntime.initialize();
   const recommendationTimer = setTimeout(() => void maybeRecommendRExtension(context), 2000);
   context.subscriptions.push(new vscode.Disposable(() => clearTimeout(recommendationTimer)));

--- a/src/test/suite/packageManifest.test.ts
+++ b/src/test/suite/packageManifest.test.ts
@@ -14,13 +14,13 @@ describe("package manifest", () => {
     assert.ok(packageJson.contributes.commands.some((entry) => entry.command === "rmdNotebooks.runInlineCell"));
   });
 
-  it("contributes HTML preview without duplicating Quarto's notebook button", () => {
+  it("contributes HTML preview for both Rmd and qmd notebooks", () => {
     assert.ok(packageJson.contributes.commands.some((entry) => entry.command === "rmdNotebooks.previewHtml"));
     const previewMenus = packageJson.contributes.menus["notebook/toolbar"].filter(
       (entry) => entry.command === "rmdNotebooks.previewHtml"
     );
     assert.equal(previewMenus.length, 2);
     assert.ok(previewMenus.some((entry) => entry.when.includes("resourceExtname =~")));
-    assert.ok(previewMenus.some((entry) => entry.when.includes("!rmdNotebooks.quartoExtensionInstalled")));
+    assert.ok(previewMenus.some((entry) => entry.when.endsWith("resourceExtname == .qmd")));
   });
 });

--- a/src/test/suite/packageManifest.test.ts
+++ b/src/test/suite/packageManifest.test.ts
@@ -13,4 +13,14 @@ describe("package manifest", () => {
   it("contributes an inline R execution command", () => {
     assert.ok(packageJson.contributes.commands.some((entry) => entry.command === "rmdNotebooks.runInlineCell"));
   });
+
+  it("contributes HTML preview without duplicating Quarto's notebook button", () => {
+    assert.ok(packageJson.contributes.commands.some((entry) => entry.command === "rmdNotebooks.previewHtml"));
+    const previewMenus = packageJson.contributes.menus["notebook/toolbar"].filter(
+      (entry) => entry.command === "rmdNotebooks.previewHtml"
+    );
+    assert.equal(previewMenus.length, 2);
+    assert.ok(previewMenus.some((entry) => entry.when.includes("resourceExtname =~")));
+    assert.ok(previewMenus.some((entry) => entry.when.includes("!rmdNotebooks.quartoExtensionInstalled")));
+  });
 });

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -176,10 +176,12 @@ describe("Rmd Notebooks Notebook Host", () => {
       services
     );
     assert.equal(qmdResult, "previewed");
-    assert.deepEqual(calls.slice(0, 3), [
+    assert.deepEqual(calls.slice(0, 5), [
       "save:qmd",
       "ensure:quarto.quarto:quarto.preview",
-      "execute:quarto.preview"
+      "openRaw",
+      "execute:quarto.preview",
+      "restoreNotebook"
     ]);
 
     await assert.rejects(

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { afterEach, before, beforeEach, describe, it } from "mocha";
 import * as vscode from "vscode";
+import { PreviewServices, previewNotebookHtml } from "../../../src/commands/previewHtml";
 
 interface InlineChunksExtensionApi {
   getDocumentState(documentUri: string): Promise<{
@@ -138,6 +139,120 @@ describe("Rmd Notebooks Notebook Host", () => {
     );
 
     assert.equal(vscode.window.activeNotebookEditor?.notebook.notebookType, "rmd-notebooks-vscode-notebook");
+  });
+
+  it("routes saved notebook previews and restores Rmd notebook view after failures", async () => {
+    const calls: string[] = [];
+    const services: PreviewServices = {
+      ensureIntegration: async (extensionId, commandId) => {
+        calls.push(`ensure:${extensionId}:${commandId}`);
+        return true;
+      },
+      executeCommand: async (commandId) => {
+        calls.push(`execute:${commandId}`);
+        if (commandId === "r.rmarkdown.showPreviewToSide") {
+          throw new Error("preview failed");
+        }
+      },
+      openRawSource: async () => {
+        calls.push("openRaw");
+      },
+      restoreNotebook: async () => {
+        calls.push("restoreNotebook");
+      },
+      showWarning: async (message) => {
+        calls.push(`warning:${message}`);
+      }
+    };
+
+    const qmdResult = await previewNotebookHtml(
+      {
+        uri: vscode.Uri.file("/tmp/preview.qmd"),
+        save: async () => {
+          calls.push("save:qmd");
+          return true;
+        }
+      },
+      services
+    );
+    assert.equal(qmdResult, "previewed");
+    assert.deepEqual(calls.slice(0, 3), [
+      "save:qmd",
+      "ensure:quarto.quarto:quarto.preview",
+      "execute:quarto.preview"
+    ]);
+
+    await assert.rejects(
+      previewNotebookHtml(
+        {
+          uri: vscode.Uri.file("/tmp/preview.Rmd"),
+          save: async () => {
+            calls.push("save:rmd");
+            return true;
+          }
+        },
+        services
+      ),
+      /preview failed/
+    );
+    assert.deepEqual(calls.slice(-5), [
+      "save:rmd",
+      "ensure:REditorSupport.r:r.rmarkdown.showPreviewToSide",
+      "openRaw",
+      "execute:r.rmarkdown.showPreviewToSide",
+      "restoreNotebook"
+    ]);
+  });
+
+  it("does not preview when saving is cancelled or an integration is missing", async () => {
+    const calls: string[] = [];
+    const services: PreviewServices = {
+      ensureIntegration: async () => {
+        calls.push("ensure");
+        return false;
+      },
+      executeCommand: async () => {
+        calls.push("execute");
+      },
+      openRawSource: async () => {
+        calls.push("openRaw");
+      },
+      restoreNotebook: async () => {
+        calls.push("restoreNotebook");
+      },
+      showWarning: async () => {
+        calls.push("warning");
+      }
+    };
+
+    const cancelled = await previewNotebookHtml(
+      { uri: vscode.Uri.file("/tmp/preview.qmd"), save: async () => false },
+      services
+    );
+    assert.equal(cancelled, "cancelled");
+    assert.deepEqual(calls, ["warning"]);
+
+    const missing = await previewNotebookHtml(
+      { uri: vscode.Uri.file("/tmp/preview.qmd"), save: async () => true },
+      services
+    );
+    assert.equal(missing, "missing");
+    assert.deepEqual(calls, ["warning", "ensure"]);
+
+    let unsupportedSaveCalled = false;
+    const unsupported = await previewNotebookHtml(
+      {
+        uri: vscode.Uri.file("/tmp/preview.md"),
+        save: async () => {
+          unsupportedSaveCalled = true;
+          return true;
+        }
+      },
+      services
+    );
+    assert.equal(unsupported, "unsupported");
+    assert.equal(unsupportedSaveCalled, false);
+    assert.deepEqual(calls, ["warning", "ensure", "warning"]);
   });
 
   it("runs the current qmd chunk and renders stdout inline", async () => {


### PR DESCRIPTION
## What changed

- add a public `rmdNotebooks.previewHtml` command and notebook toolbar action for both `.Rmd` and `.qmd`
- save the notebook before previewing
- temporarily activate the raw source before invoking vscode-R or Quarto, then restore notebook focus in `finally`
- provide extension-search guidance when an integration is unavailable
- always show the unified `.qmd` toolbar action in this custom notebook view

## Why the qmd handoff is necessary

Quarto identifies an active notebook from its first cell. Rmd Notebooks now represents frontmatter as a YAML first cell, which Quarto does not recognize as a Quarto document. Activating the saved `.qmd` source gives Quarto the correct document URI and language before `quarto.preview` runs.

## Validation

- rebased onto current `main`, including frontmatter and inline-R prose
- `npm run test:unit` — 46 passing
- `npm run test:vscode` — 44 passing
- `npm run package:vsix:marketplace`
- `npm run package:vsix:openvsx`
- both GitHub Actions checks passing

Fixes #21