### PR TITLE
feat: execute inline R in rendered prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - show document frontmatter as an editable, syntax-highlighted YAML cell without making it executable (#19)
+- evaluate native knitr and Quarto inline R expressions in rendered, source-preserving prose cells (#20)
 
 ## 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The VS Code Marketplace package installs the [vscode-R extension](https://market
 - Evaluates inline chunks in `.GlobalEnv`, so user variables are normal R workspace variables
 - Honors normal R startup files by default, including project `.Rprofile` files used by tools such as `renv`
 - Shows inline stdout, stderr, HTML snippets, static PNG plots, and theme-aware data-frame tables
+- Evaluates native knitr and Quarto inline R expressions inside rendered prose cells
 - Shows execution-order badges per notebook and resets them when its R session restarts
 - Persists outputs and restores them when the document is reopened
 - Marks outputs stale after code edits
@@ -85,6 +86,7 @@ If you do not want inline sessions to source vscode-R's watcher, disable:
 
 - `Rmd Notebooks: Run Current Chunk`
 - `Rmd Notebooks: Run All Chunks`
+- `Rmd Notebooks: Run Inline R`
 - `Rmd Notebooks: Stop All Running Chunks`
 - `Rmd Notebooks: Clear Current Output`
 - `Rmd Notebooks: Clear All Outputs`
@@ -116,6 +118,8 @@ Inline R sessions honor normal startup files by default. To isolate inline sessi
   "rmdNotebooks.r.args": ["--slave", "--vanilla"]
 }
 ```
+
+Rendered prose supports both native knitr syntax, such as `` `r value` ``, and Quarto syntax, such as `` `{r} value` ``. Inline prose requires the R package `knitr`; install it with `install.packages("knitr")` if it is not already available. Inline results are textual/Markdown values; plots and rich widgets remain regular chunk outputs.
 
 ## Development
 

--- a/media/r/rmd_notebooks_session.R
+++ b/media/r/rmd_notebooks_session.R
@@ -35,6 +35,14 @@ rmd_notebooks_render_html <- function(value) {
   NULL
 }
 
+rmd_notebooks_render_markdown <- function(value) {
+  if (inherits(value, "rmd_notebooks_markdown")) {
+    return(value$markdown)
+  }
+
+  NULL
+}
+
 rmd_notebooks_escape_html <- function(text) {
   text <- as.character(text)
   text <- gsub("&", "&amp;", text, fixed = TRUE)
@@ -425,6 +433,7 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
   stdout_buffer <- character()
   stderr_buffer <- character()
   html_buffer <- character()
+  markdown_buffer <- character()
   stdout_connection <- textConnection("stdout_buffer", "w", local = TRUE)
   stderr_connection <- textConnection("stderr_buffer", "w", local = TRUE)
   assign("active_stdout_connection", stdout_connection, envir = protocol_env)
@@ -452,14 +461,19 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
       for (expression in expressions) {
         result <- withVisible(eval(expression, envir = user_env))
         if (result$visible && !is.null(result$value)) {
-          html_output <- rmd_notebooks_render_html(result$value)
-          if (is.null(html_output) && isTRUE(df_render) && is.data.frame(result$value)) {
-            html_output <- rmd_notebooks_data_frame_to_html(result$value, df_max_rows, df_max_columns)
-          }
-          if (!is.null(html_output)) {
-            html_buffer <- c(html_buffer, html_output)
+          markdown_output <- rmd_notebooks_render_markdown(result$value)
+          if (!is.null(markdown_output)) {
+            markdown_buffer <- c(markdown_buffer, markdown_output)
           } else {
-            print(result$value)
+            html_output <- rmd_notebooks_render_html(result$value)
+            if (is.null(html_output) && isTRUE(df_render) && is.data.frame(result$value)) {
+              html_output <- rmd_notebooks_data_frame_to_html(result$value, df_max_rows, df_max_columns)
+            }
+            if (!is.null(html_output)) {
+              html_buffer <- c(html_buffer, html_output)
+            } else {
+              print(result$value)
+            }
           }
         }
       }
@@ -494,6 +508,7 @@ rmd_notebooks_execute <- function(code, working_directory, artifact_directory, p
     stdout = stdout_buffer,
     stderr = stderr_buffer,
     html = html_buffer,
+    markdown = markdown_buffer,
     plots = rmd_notebooks_collect_plot_paths(artifact_directory, started_at)
   )
 }
@@ -588,6 +603,7 @@ repeat {
   rmd_notebooks_emit_section("STDOUT", result$stdout)
   rmd_notebooks_emit_section("STDERR", result$stderr)
   rmd_notebooks_emit_section("HTML", result$html)
+  rmd_notebooks_emit_section("MARKDOWN", result$markdown)
   rmd_notebooks_emit_section("PLOTS", result$plots)
   cat("RMD_NOTEBOOKS_RESULT_END\n")
   flush.console()

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
         "title": "Rmd Notebooks: Run All Chunks"
       },
       {
+        "command": "rmdNotebooks.runInlineCell",
+        "title": "Rmd Notebooks: Run Inline R"
+      },
+      {
         "command": "rmdNotebooks.interruptSession",
         "title": "Stop All Running Chunks",
         "category": "Rmd Notebooks",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -11,6 +11,12 @@ export function registerCommands(controller: InlineChunksNotebookRuntime): vscod
     vscode.commands.registerCommand("rmdNotebooks.runAllChunks", async (documentUri?: string) => {
       await controller.runAllChunks(documentUri);
     }),
+    vscode.commands.registerCommand(
+      "rmdNotebooks.runInlineCell",
+      async (documentUri?: string, chunkId?: string, cellIndex?: number) => {
+        await controller.runInlineCell(documentUri, chunkId, cellIndex);
+      }
+    ),
     vscode.commands.registerCommand("rmdNotebooks.interruptSession", async (documentUri?: string) => {
       await controller.interruptSession(documentUri);
     }),

--- a/src/document/chunkTypes.ts
+++ b/src/document/chunkTypes.ts
@@ -74,11 +74,17 @@ export interface HtmlOutputItem {
   html: string;
 }
 
+export interface MarkdownOutputItem {
+  type: "markdown";
+  markdown: string;
+}
+
 export type OutputItem =
   | TextOutputItem
   | ErrorOutputItem
   | ImageOutputItem
-  | HtmlOutputItem;
+  | HtmlOutputItem
+  | MarkdownOutputItem;
 
 export type ChunkOutputStatus = "running" | "success" | "error" | "redirected" | "cancelled";
 
@@ -96,4 +102,5 @@ export interface ChunkOutputRecord {
   stale: boolean;
   status: ChunkOutputStatus;
   outputs: OutputItem[];
+  sourceKind?: "chunk" | "inline";
 }

--- a/src/editor/outputChannelController.ts
+++ b/src/editor/outputChannelController.ts
@@ -108,6 +108,12 @@ function formatOutputs(record: ChunkOutputRecord): string[] {
     if (output.type === "html") {
       lines.push("[html]");
       lines.push(output.html);
+      continue;
+    }
+
+    if (output.type === "markdown") {
+      lines.push("[markdown]");
+      lines.push(output.markdown);
     }
   }
 

--- a/src/execution/rExecutor.ts
+++ b/src/execution/rExecutor.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import * as vscode from "vscode";
-import { ErrorOutputItem, HtmlOutputItem, ImageOutputItem, OutputItem, TextOutputItem } from "../document/chunkTypes";
+import { ErrorOutputItem, HtmlOutputItem, ImageOutputItem, MarkdownOutputItem, OutputItem, TextOutputItem } from "../document/chunkTypes";
 import {
   Executor,
   ExecutionCancellationToken,
@@ -32,6 +32,7 @@ interface RawExecutionPayload {
   stdout: string;
   stderr: string;
   html: string;
+  markdown: string;
   plots: string[];
 }
 
@@ -122,6 +123,13 @@ export class RExecutor implements Executor {
         type: "html",
         html: payload.html.trim()
       } satisfies HtmlOutputItem);
+    }
+
+    if (payload.markdown.trim().length > 0) {
+      items.push({
+        type: "markdown",
+        markdown: payload.markdown.trimEnd()
+      } satisfies MarkdownOutputItem);
     }
 
     for (const plotPath of payload.plots) {
@@ -635,6 +643,7 @@ function parseRawExecutionPayload(lines: string[]): RawExecutionPayload {
     stdout: (sections.get("STDOUT") ?? []).join("\n"),
     stderr: (sections.get("STDERR") ?? []).join("\n"),
     html: (sections.get("HTML") ?? []).join("\n"),
+    markdown: (sections.get("MARKDOWN") ?? []).join("\n"),
     plots: (sections.get("PLOTS") ?? []).filter((entry) => entry.trim().length > 0)
   };
 }

--- a/src/notebook/cellStatusBarProvider.ts
+++ b/src/notebook/cellStatusBarProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { formatChunkHeaderBadge, formatChunkHeaderTooltip } from "./metadataDisplay";
+import { parseInlineRExpressions } from "./inlineR";
 import { getInlineChunksMetadata, INLINE_CHUNKS_NOTEBOOK_TYPE } from "./notebookTypes";
 
 interface ChunkIdLookup {
@@ -13,11 +14,33 @@ export class InlineChunksCellStatusBarProvider implements vscode.NotebookCellSta
     cell: vscode.NotebookCell,
     _token: vscode.CancellationToken
   ): vscode.NotebookCellStatusBarItem | vscode.NotebookCellStatusBarItem[] | undefined {
-    if (cell.notebook.notebookType !== INLINE_CHUNKS_NOTEBOOK_TYPE || cell.kind !== vscode.NotebookCellKind.Code) {
+    if (cell.notebook.notebookType !== INLINE_CHUNKS_NOTEBOOK_TYPE) {
       return undefined;
     }
 
     const metadata = getInlineChunksMetadata(cell.metadata);
+    const inlineCount = metadata?.kind === "inline" || cell.kind === vscode.NotebookCellKind.Markup
+      ? parseInlineRExpressions(cell.document.getText()).length
+      : 0;
+    if (inlineCount > 0) {
+      const chunkId = this.chunkIdLookup.getChunkIdForCell(cell.notebook.uri.toString(), cell.index);
+      const item = new vscode.NotebookCellStatusBarItem(
+        `$(play) Inline R ×${inlineCount}`,
+        vscode.NotebookCellStatusBarAlignment.Left
+      );
+      item.tooltip = "Run inline R expressions and render this prose cell";
+      item.priority = 210;
+      item.command = {
+        title: "Run Inline R",
+        command: "rmdNotebooks.runInlineCell",
+        arguments: [cell.notebook.uri.toString(), chunkId, cell.index]
+      };
+      return item;
+    }
+
+    if (cell.kind !== vscode.NotebookCellKind.Code) {
+      return undefined;
+    }
     if (metadata?.kind !== "code") {
       return undefined;
     }

--- a/src/notebook/inlineR.ts
+++ b/src/notebook/inlineR.ts
@@ -1,0 +1,104 @@
+export type InlineRSyntax = "knitr" | "quarto";
+
+export interface InlineRExpression {
+  syntax: InlineRSyntax;
+  expression: string;
+  start: number;
+  end: number;
+}
+
+export function parseInlineRExpressions(markdown: string): InlineRExpression[] {
+  const expressions: InlineRExpression[] = [];
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (markdown[index] !== "`" || isEscaped(markdown, index)) {
+      continue;
+    }
+
+    const openingLength = backtickRunLength(markdown, index);
+    if (openingLength !== 1) {
+      index += openingLength - 1;
+      continue;
+    }
+
+    const closing = findClosingBacktick(markdown, index + 1);
+    if (closing === -1) {
+      break;
+    }
+
+    const content = markdown.slice(index + 1, closing);
+    const quarto = content.match(/^\{r\}\s+([\s\S]+)$/i);
+    const knitr = content.match(/^r\s+([\s\S]+)$/);
+    const match = quarto ?? knitr;
+    if (match && match[1].trim().length > 0) {
+      expressions.push({
+        syntax: quarto ? "quarto" : "knitr",
+        expression: match[1].trim(),
+        start: index,
+        end: closing + 1
+      });
+    }
+
+    index = closing;
+  }
+
+  return expressions;
+}
+
+export function normalizeInlineRForKnitr(markdown: string): string {
+  const expressions = parseInlineRExpressions(markdown);
+  if (expressions.length === 0) {
+    return markdown;
+  }
+
+  let normalized = "";
+  let cursor = 0;
+  for (const expression of expressions) {
+    normalized += markdown.slice(cursor, expression.start);
+    normalized += `\`r ${expression.expression}\``;
+    cursor = expression.end;
+  }
+  return normalized + markdown.slice(cursor);
+}
+
+export function buildInlineRExecutionCode(markdown: string): string {
+  const normalized = normalizeInlineRForKnitr(markdown).replace(/\r\n/g, "\n");
+  const encoded = encodeURIComponent(normalized).replace(/'/g, "%27");
+  return [
+    "local({",
+    "if (!requireNamespace('knitr', quietly = TRUE)) stop(\"Inline R prose requires the knitr package. Install it with install.packages('knitr').\")",
+    `.rmd_markdown <- utils::URLdecode('${encoded}')`,
+    ".rmd_rendered <- knitr::knit(text = .rmd_markdown, quiet = TRUE, envir = .GlobalEnv)",
+    "structure(list(markdown = paste(.rmd_rendered, collapse = '\\n')), class = 'rmd_notebooks_markdown')",
+    "})"
+  ].join("\n");
+}
+
+function findClosingBacktick(markdown: string, start: number): number {
+  for (let index = start; index < markdown.length; index += 1) {
+    if (markdown[index] !== "`" || isEscaped(markdown, index)) {
+      continue;
+    }
+    if (backtickRunLength(markdown, index) === 1) {
+      return index;
+    }
+    index += backtickRunLength(markdown, index) - 1;
+  }
+  return -1;
+}
+
+function backtickRunLength(value: string, start: number): number {
+  let length = 0;
+  while (value[start + length] === "`") {
+    length += 1;
+  }
+  return length;
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}

--- a/src/notebook/notebookRuntime.ts
+++ b/src/notebook/notebookRuntime.ts
@@ -23,11 +23,13 @@ import {
 } from "./notebookTypes";
 import { applyChunkOptionsToResult, parseChunkOptions } from "./chunkOptions";
 import { buildChunkHeader, extractChunkLabel, normalizeChunkHeaderInfo, validateChunkHeaderInfo } from "./chunkHeader";
+import { buildInlineRExecutionCode, parseInlineRExpressions } from "./inlineR";
 
 interface NotebookChunkCell {
   index: number;
   cell: vscode.NotebookCell;
   chunk: ExecutableChunk;
+  sourceKind: "chunk" | "inline";
 }
 
 interface NotebookSnapshot {
@@ -45,7 +47,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
   private readonly metadataSyncInFlight = new Set<string>();
   private readonly outputSyncInFlight = new Set<string>();
+  private readonly outputRestorations = new Map<string, Promise<void>>();
+  private readonly inlineStaleTimers = new Map<string, NodeJS.Timeout>();
   private readonly executionAdmissions = new Map<string, Promise<void>>();
+  private readonly collapsedInlineDocuments = new Set<string>();
   // Notebooks whose in-flight Run All / multi-cell run should stop before the next
   // cell. Set by interruptSession ("Stop All"), checked between cells in the run loops.
   private readonly runsToAbort = new Set<string>();
@@ -64,7 +69,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       INLINE_CHUNKS_NOTEBOOK_TYPE,
       "Rmd Notebooks"
     );
-    this.controller.supportedLanguages = ["r"];
+    this.controller.supportedLanguages = ["r", "markdown"];
     this.controller.supportsExecutionOrder = true;
     this.controller.executeHandler = async (cells, notebook) => {
       const documentUri = notebook.uri.toString();
@@ -91,7 +96,9 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       vscode.workspace.onDidCloseNotebookDocument((notebook) => void this.handleNotebookClosed(notebook)),
       vscode.window.onDidChangeActiveNotebookEditor((editor) => {
         if (editor && isInlineChunksNotebook(editor.notebook)) {
-          void this.restoreOutputsToNotebook(editor.notebook);
+          void this.restoreOutputsToNotebook(editor.notebook)
+            .then(() => this.collapseInlineInputs(editor.notebook))
+            .catch((error) => console.error("Unable to restore Rmd notebook outputs", error));
         }
       })
     );
@@ -102,6 +109,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   public async runCurrentChunk(documentUri?: string, chunkId?: string): Promise<void> {
+    const notebook = this.resolveNotebook(documentUri);
+    if (notebook) {
+      await this.promoteSelectedInlineMarkup(notebook);
+    }
     const resolved = await this.resolveCodeCell(documentUri, chunkId);
     if (!resolved) {
       void vscode.window.showWarningMessage("Rmd Notebooks: select an R code cell to run it.");
@@ -109,6 +120,35 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     }
 
     await this.executeCell(resolved.notebook, resolved.cell);
+    if (getInlineChunksMetadata(resolved.cell.metadata)?.kind === "inline") {
+      await this.collapseInlineInputs(resolved.notebook, [resolved.cell.index], true);
+    }
+  }
+
+  public async runInlineCell(documentUri?: string, chunkId?: string, cellIndex?: number): Promise<void> {
+    const notebook = this.resolveNotebook(documentUri);
+    if (!notebook) {
+      return;
+    }
+
+    if (typeof cellIndex === "number") {
+      await this.promoteInlineMarkupCells(notebook, [cellIndex]);
+      const cell = notebook.cellAt(cellIndex);
+      if (getInlineChunksMetadata(cell.metadata)?.kind === "inline") {
+        await this.executeCell(notebook, cell);
+        await this.collapseInlineInputs(notebook, [cell.index], true);
+        return;
+      }
+    } else {
+      await this.promoteSelectedInlineMarkup(notebook);
+    }
+    const resolved = await this.resolveCodeCell(documentUri, chunkId);
+    if (!resolved || getInlineChunksMetadata(resolved.cell.metadata)?.kind !== "inline") {
+      void vscode.window.showWarningMessage("Rmd Notebooks: select prose containing inline R to run it.");
+      return;
+    }
+    await this.executeCell(resolved.notebook, resolved.cell);
+    await this.collapseInlineInputs(resolved.notebook, [resolved.cell.index], true);
   }
 
   public async runAllChunks(documentUri?: string): Promise<void> {
@@ -117,6 +157,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return;
     }
 
+    await this.promoteInlineMarkupCells(notebook);
     const uri = notebook.uri.toString();
     this.runsToAbort.delete(uri);
     const snapshot = await this.refreshNotebook(notebook);
@@ -130,6 +171,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       }
     }
     this.runsToAbort.delete(uri);
+    await this.collapseInlineInputs(notebook, undefined, true);
   }
 
   // Stops the whole run at once: interrupts the chunk currently running, cancels every
@@ -173,7 +215,11 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     await this.withOutputSync(resolved.notebook.uri.toString(), async () => {
       const execution = this.controller.createNotebookCellExecution(resolved.notebook.cellAt(entry.index));
       execution.start(Date.now());
-      await execution.clearOutput();
+      if (entry.sourceKind === "inline") {
+        await execution.replaceOutput(createInlineSourceOutputs(resolved.cell.document.getText()));
+      } else {
+        await execution.clearOutput();
+      }
       execution.end(undefined, Date.now());
     });
   }
@@ -197,7 +243,11 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       for (const entry of snapshot.chunks) {
         const execution = this.controller.createNotebookCellExecution(notebook.cellAt(entry.index));
         execution.start(Date.now());
-        await execution.clearOutput();
+        if (entry.sourceKind === "inline") {
+          await execution.replaceOutput(createInlineSourceOutputs(entry.cell.document.getText()));
+        } else {
+          await execution.clearOutput();
+        }
         execution.end(undefined, Date.now());
       }
     });
@@ -311,6 +361,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
   }
 
   public dispose(): void {
+    for (const timer of this.inlineStaleTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.inlineStaleTimers.clear();
     this.disposables.forEach((disposable) => disposable.dispose());
   }
 
@@ -322,6 +376,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     this.controller.updateNotebookAffinity(notebook, vscode.NotebookControllerAffinity.Preferred);
     await this.refreshNotebook(notebook);
     await this.restoreOutputsToNotebook(notebook);
+    await this.collapseInlineInputs(notebook);
   }
 
   private async handleNotebookChanged(event: vscode.NotebookDocumentChangeEvent): Promise<void> {
@@ -353,9 +408,27 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       if (changed) {
         await this.outputStore.saveDocumentOutputs(documentUri, outputs);
       }
+      const inlineCleared = clearedCells.filter(
+        (cell) => getInlineChunksMetadata(cell.metadata)?.kind === "inline"
+      );
+      if (inlineCleared.length > 0 && await this.ensureControllerSelected(notebook)) {
+        await this.withOutputSync(documentUri, async () => {
+          for (const cell of inlineCleared) {
+            const execution = this.controller.createNotebookCellExecution(notebook.cellAt(cell.index));
+            execution.start();
+            await execution.replaceOutput(createInlineSourceOutputs(cell.document.getText()));
+            execution.end(undefined);
+          }
+        });
+      }
     }
 
     await this.refreshNotebook(notebook);
+    if (event.cellChanges.some(
+      (change) => change.document !== undefined && getInlineChunksMetadata(change.cell.metadata)?.kind === "inline"
+    )) {
+      this.scheduleInlineOutputRestore(notebook);
+    }
   }
 
   private async handleNotebookClosed(notebook: vscode.NotebookDocument): Promise<void> {
@@ -364,6 +437,13 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     }
 
     this.snapshots.delete(notebook.uri.toString());
+    this.collapsedInlineDocuments.delete(notebook.uri.toString());
+    this.outputRestorations.delete(notebook.uri.toString());
+    const staleTimer = this.inlineStaleTimers.get(notebook.uri.toString());
+    if (staleTimer) {
+      clearTimeout(staleTimer);
+      this.inlineStaleTimers.delete(notebook.uri.toString());
+    }
     const executor = this.executorRegistry.get("r");
     await executor?.disposeSession?.(notebook.uri.toString());
   }
@@ -372,6 +452,8 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     if (!isExecutableChunkCell(cell)) {
       return "completed";
     }
+
+    await this.outputRestorations.get(notebook.uri.toString())?.catch(() => undefined);
 
     const releaseAdmission = await this.acquireExecutionAdmission(notebook.uri.toString());
     try {
@@ -395,6 +477,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     const outputs = await this.ensureOutputsLoaded(notebook.uri.toString());
     const executor = this.executorRegistry.get(entry.chunk.language);
     const chunkOptions = getChunkOptions(cell);
+    const isInline = entry.sourceKind === "inline";
     const selected = await this.ensureControllerSelected(notebook);
     if (!selected) {
       return "completed";
@@ -424,7 +507,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     if (chunkOptions?.eval === false) {
       beginExecutionDisplay(Date.now());
-      const skippedRecord = createRecord(entry.chunk, "success", []);
+      const skippedRecord = createRecord(entry.chunk, "success", [], entry.sourceKind);
       outputs.set(entry.chunk.identity.chunkId, skippedRecord);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
       await this.withOutputSync(notebook.uri.toString(), async () => {
@@ -438,11 +521,12 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     if (!executor) {
       beginExecutionDisplay(Date.now());
       const record = createRecord(entry.chunk, "error", [
+        ...(isInline ? inlineSourceOutputItems(cell.document.getText()) : []),
         {
           type: "error",
           text: `No executor registered for language "${entry.chunk.language}".`
         }
-      ]);
+      ], entry.sourceKind);
       outputs.set(entry.chunk.identity.chunkId, record);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
       await this.withOutputSync(notebook.uri.toString(), async () => {
@@ -453,7 +537,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       return "completed";
     }
 
-    const runningRecord = createRecord(entry.chunk, "running", []);
+    const runningRecord = createRecord(entry.chunk, "running", [], entry.sourceKind);
     outputs.set(entry.chunk.identity.chunkId, runningRecord);
     await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
     this.outputChannelController.logRunStarted(cell.document, entry.chunk);
@@ -464,10 +548,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         workspaceFolder: vscode.workspace.getWorkspaceFolder(notebook.uri)?.uri.fsPath,
         chunkId: entry.chunk.identity.chunkId,
         language: entry.chunk.language,
-        code: cell.document.getText(),
+        code: isInline ? buildInlineRExecutionCode(cell.document.getText()) : cell.document.getText(),
         header: entry.chunk.header,
         artifactDirectory: await this.outputStore.getArtifactDirectory(notebook.uri.toString()),
-        plot: resolvePlotRenderOptions(chunkOptions),
+        plot: isInline ? undefined : resolvePlotRenderOptions(chunkOptions),
         prompt: (request) => this.promptForChunkInput(notebook, cell, entry.chunk, request),
         onStart: (executionOrder) => beginExecutionDisplay(Date.now(), executionOrder),
         token: execution.token
@@ -475,14 +559,17 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
       releaseAdmission();
       const result = await resultPromise;
 
-      const filteredResult = applyChunkOptionsToResult(result, chunkOptions);
+      const filteredResult = isInline ? result : applyChunkOptionsToResult(result, chunkOptions);
+      const displayedResult = isInline && !filteredResult.success && !filteredResult.items.some((item) => item.type === "markdown")
+        ? { ...filteredResult, items: [...inlineSourceOutputItems(cell.document.getText()), ...filteredResult.items] }
+        : filteredResult;
       // onStart always fires (in the session's beginExecution) before any result can
       // arrive, so the cell is already marked running here; this call is only a
       // fallback for the impossible case where onStart was skipped, and is a no-op
       // otherwise. The displayed start time therefore comes from onStart (Date.now at
       // dequeue), not from filteredResult.startedAt.
-      beginExecutionDisplay(filteredResult.startedAt);
-      const record = createRecordFromResult(entry.chunk, filteredResult);
+      beginExecutionDisplay(displayedResult.startedAt);
+      const record = createRecordFromResult(entry.chunk, displayedResult, entry.sourceKind);
       outputs.set(entry.chunk.identity.chunkId, record);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
       await this.withOutputSync(notebook.uri.toString(), async () => {
@@ -492,7 +579,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
           await execution.replaceOutput(await createNotebookOutputs(record));
         }
       });
-      execution.end(filteredResult.success, filteredResult.finishedAt);
+      execution.end(displayedResult.success, displayedResult.finishedAt);
       this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
       return "completed";
     } catch (error) {
@@ -500,6 +587,20 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         // The chunk did start running (it timed out mid-execution), so the cell is
         // already showing as running by now; this only matters as a safeguard.
         beginExecutionDisplay(Date.now());
+        if (isInline) {
+          const record = createRecord(entry.chunk, "error", [
+            ...inlineSourceOutputItems(cell.document.getText()),
+            { type: "error", text: error.message }
+          ], "inline");
+          outputs.set(entry.chunk.identity.chunkId, record);
+          await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
+          await this.withOutputSync(notebook.uri.toString(), async () => {
+            await execution.replaceOutput(await createNotebookOutputs(record));
+          });
+          execution.end(false, Date.now());
+          this.outputChannelController.logRunCompleted(cell.document, entry.chunk, record);
+          return "completed";
+        }
         const fallback = await this.handleInteractiveFallback(notebook, cell, entry.chunk, outputs, execution, error.message);
         this.outputChannelController.logRunCompleted(cell.document, entry.chunk, fallback.record);
         return fallback.launchedTerminal ? "redirected" : "completed";
@@ -511,11 +612,20 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         // duration (start() must be called before end(), but with no start time so
         // no clock is shown), and clear it without flagging it as a failure.
         beginExecutionDisplay(undefined);
-        const cancelledRecord = createRecord(entry.chunk, "cancelled", []);
+        const cancelledRecord = createRecord(
+          entry.chunk,
+          "cancelled",
+          isInline ? inlineSourceOutputItems(cell.document.getText()) : [],
+          entry.sourceKind
+        );
         outputs.set(entry.chunk.identity.chunkId, cancelledRecord);
         await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
         await this.withOutputSync(notebook.uri.toString(), async () => {
-          await execution.clearOutput();
+          if (isInline) {
+            await execution.replaceOutput(await createNotebookOutputs(cancelledRecord));
+          } else {
+            await execution.clearOutput();
+          }
         });
         execution.end(undefined, Date.now());
         this.outputChannelController.logRunCompleted(cell.document, entry.chunk, cancelledRecord);
@@ -524,11 +634,12 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
       beginExecutionDisplay(Date.now());
       const record = createRecord(entry.chunk, "error", [
+        ...(isInline ? inlineSourceOutputItems(cell.document.getText()) : []),
         {
           type: "error",
           text: error instanceof Error ? error.message : String(error)
         }
-      ]);
+      ], entry.sourceKind);
       outputs.set(entry.chunk.identity.chunkId, record);
       await this.outputStore.saveDocumentOutputs(notebook.uri.toString(), outputs);
       await this.withOutputSync(notebook.uri.toString(), async () => {
@@ -567,7 +678,7 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
   public async runCurrentChunkInTerminal(documentUri?: string, chunkId?: string): Promise<void> {
     const resolved = await this.resolveCodeCell(documentUri, chunkId);
-    if (!resolved) {
+    if (!resolved || getInlineChunksMetadata(resolved.cell.metadata)?.kind !== "code") {
       void vscode.window.showWarningMessage("Rmd Notebooks: select an R code cell to run it in the terminal.");
       return;
     }
@@ -664,6 +775,9 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     for (const entry of snapshot.chunks) {
       const existing = getInlineChunksMetadata(entry.cell.metadata);
+      if (entry.sourceKind === "inline" && existing?.kind === "inline") {
+        continue;
+      }
 
       const targetSource: InlineChunksCodeCellMetadata = {
         kind: "code",
@@ -697,7 +811,40 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
     return true;
   }
 
-  private async restoreOutputsToNotebook(notebook: vscode.NotebookDocument): Promise<void> {
+  private restoreOutputsToNotebook(notebook: vscode.NotebookDocument): Promise<void> {
+    const documentUri = notebook.uri.toString();
+    const previous = this.outputRestorations.get(documentUri) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() => this.performOutputRestore(notebook));
+    this.outputRestorations.set(documentUri, current);
+    const cleanup = (): void => {
+      if (this.outputRestorations.get(documentUri) === current) {
+        this.outputRestorations.delete(documentUri);
+      }
+    };
+    void current.then(cleanup, cleanup);
+    return current;
+  }
+
+  private scheduleInlineOutputRestore(notebook: vscode.NotebookDocument): void {
+    const documentUri = notebook.uri.toString();
+    const existing = this.inlineStaleTimers.get(documentUri);
+    if (existing) {
+      clearTimeout(existing);
+    }
+    const timer = setTimeout(() => {
+      this.inlineStaleTimers.delete(documentUri);
+      if (vscode.workspace.notebookDocuments.some((candidate) => candidate.uri.toString() === documentUri)) {
+        void this.restoreOutputsToNotebook(notebook).catch((error) =>
+          console.error("Unable to refresh stale inline R output", error)
+        );
+      }
+    }, 250);
+    this.inlineStaleTimers.set(documentUri, timer);
+  }
+
+  private async performOutputRestore(notebook: vscode.NotebookDocument): Promise<void> {
     // On a window reload a notebook can become the active editor before its
     // snapshot has been built (the active-editor event races with initialize),
     // so build it on demand instead of bailing out and never restoring.
@@ -713,10 +860,10 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
 
     const pending = snapshot.chunks.filter((entry) => {
       const record = outputs.get(entry.chunk.identity.chunkId);
-      if (!record) {
+      if (!record || record.status === "running") {
         return false;
       }
-      return notebook.cellAt(entry.index).outputs.length === 0;
+      return entry.sourceKind === "inline" || notebook.cellAt(entry.index).outputs.length === 0;
     });
     if (pending.length === 0) {
       return;
@@ -742,6 +889,73 @@ export class InlineChunksNotebookRuntime implements vscode.Disposable {
         execution.end(record.status === "success");
       }
     });
+  }
+
+  private async promoteSelectedInlineMarkup(notebook: vscode.NotebookDocument): Promise<void> {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor || editor.notebook.uri.toString() !== notebook.uri.toString()) {
+      return;
+    }
+    const indices: number[] = [];
+    for (let index = editor.selection.start; index < editor.selection.end; index += 1) {
+      indices.push(index);
+    }
+    await this.promoteInlineMarkupCells(notebook, indices);
+  }
+
+  private async promoteInlineMarkupCells(notebook: vscode.NotebookDocument, indices?: number[]): Promise<void> {
+    const allowed = indices ? new Set(indices) : undefined;
+    const edits: vscode.NotebookEdit[] = [];
+
+    for (const cell of notebook.getCells()) {
+      if (cell.kind !== vscode.NotebookCellKind.Markup || (allowed && !allowed.has(cell.index))) {
+        continue;
+      }
+      const expressions = parseInlineRExpressions(cell.document.getText());
+      if (expressions.length === 0) {
+        continue;
+      }
+      const replacement = createInlineCellData(cell.document.getText(), expressions.length);
+      edits.push(vscode.NotebookEdit.replaceCells(new vscode.NotebookRange(cell.index, cell.index + 1), [replacement]));
+    }
+
+    if (edits.length === 0) {
+      return;
+    }
+    await this.withMetadataSync(notebook.uri.toString(), async () => {
+      const edit = new vscode.WorkspaceEdit();
+      edit.set(notebook.uri, edits);
+      await vscode.workspace.applyEdit(edit);
+    });
+    await this.refreshNotebook(notebook);
+  }
+
+  private async collapseInlineInputs(
+    notebook: vscode.NotebookDocument,
+    indices?: number[],
+    force = false
+  ): Promise<void> {
+    const documentUri = notebook.uri.toString();
+    if (!force && this.collapsedInlineDocuments.has(documentUri)) {
+      return;
+    }
+    if (!vscode.window.visibleNotebookEditors.some((editor) => editor.notebook.uri.toString() === documentUri)) {
+      return;
+    }
+    const allowed = indices ? new Set(indices) : undefined;
+    const ranges = notebook.getCells()
+      .filter((cell) => getInlineChunksMetadata(cell.metadata)?.kind === "inline" && (!allowed || allowed.has(cell.index)))
+      .map((cell) => ({ start: cell.index, end: cell.index + 1 }));
+    if (ranges.length === 0) {
+      return;
+    }
+    await vscode.commands.executeCommand("notebook.cell.collapseCellInput", {
+      document: notebook.uri,
+      ranges
+    });
+    if (!indices) {
+      this.collapsedInlineDocuments.add(documentUri);
+    }
   }
 
   private resolveNotebook(documentUri?: string): vscode.NotebookDocument | undefined {
@@ -949,6 +1163,7 @@ function buildNotebookSnapshot(
     .map((cell) => ({
       cell,
       index: cell.index,
+      sourceKind: getInlineChunksMetadata(cell.metadata)?.kind === "inline" ? "inline" as const : "chunk" as const,
       parsed: toParsedChunk(notebook, cell)
     }));
 
@@ -981,7 +1196,8 @@ function buildNotebookSnapshot(
     chunks: codeCells.map((entry, index) => ({
       index: entry.index,
       cell: entry.cell,
-      chunk: chunks[index]
+      chunk: chunks[index],
+      sourceKind: entry.sourceKind
     })),
     generatedAt: Date.now()
   };
@@ -997,8 +1213,9 @@ function isExecutableChunkCell(cell: vscode.NotebookCell): boolean {
 
 function toParsedChunk(notebook: vscode.NotebookDocument, cell: vscode.NotebookCell): ParsedExecutableChunk {
   const metadata = getInlineChunksMetadata(cell.metadata);
+  const isInline = metadata?.kind === "inline";
   const codeMetadata = metadata?.kind === "code" ? metadata : undefined;
-  const header = codeMetadata?.header ?? `\`\`\`{${cell.document.languageId}}`;
+  const header = isInline ? "inline-r" : codeMetadata?.header ?? `\`\`\`{${cell.document.languageId}}`;
   const body = cell.document.getText();
   const startLine = cell.index * 2;
   const bodyLineCount = body.length === 0 ? 0 : body.replace(/\r\n/g, "\n").split("\n").length;
@@ -1006,9 +1223,9 @@ function toParsedChunk(notebook: vscode.NotebookDocument, cell: vscode.NotebookC
 
   return {
     documentUri: notebook.uri.toString(),
-    language: cell.document.languageId,
+    language: isInline ? "r" : cell.document.languageId,
     header,
-    headerInfo: codeMetadata?.headerInfo ?? cell.document.languageId,
+    headerInfo: isInline ? "r inline" : codeMetadata?.headerInfo ?? cell.document.languageId,
     label: codeMetadata?.label,
     body,
     isClosed: true,
@@ -1052,6 +1269,7 @@ function reconcileOutputs(snapshot: NotebookSnapshot, outputs: Map<string, Chunk
     record.headerHash = entry.chunk.identity.headerHash;
     record.bodyHash = entry.chunk.identity.bodyHash;
     record.stale = record.contentHash !== entry.chunk.identity.contentHash;
+    record.sourceKind = entry.sourceKind;
   }
 
   for (const [chunkId, record] of outputs) {
@@ -1061,7 +1279,12 @@ function reconcileOutputs(snapshot: NotebookSnapshot, outputs: Map<string, Chunk
   }
 }
 
-function createRecord(chunk: ExecutableChunk, status: ChunkOutputRecord["status"], outputs: ChunkOutputRecord["outputs"]): ChunkOutputRecord {
+function createRecord(
+  chunk: ExecutableChunk,
+  status: ChunkOutputRecord["status"],
+  outputs: ChunkOutputRecord["outputs"],
+  sourceKind: "chunk" | "inline" = "chunk"
+): ChunkOutputRecord {
   return {
     documentUri: chunk.documentUri,
     chunkId: chunk.identity.chunkId,
@@ -1075,11 +1298,16 @@ function createRecord(chunk: ExecutableChunk, status: ChunkOutputRecord["status"
     capturedAt: Date.now(),
     stale: false,
     status,
-    outputs
+    outputs,
+    sourceKind
   };
 }
 
-function createRecordFromResult(chunk: ExecutableChunk, result: ExecutionResult): ChunkOutputRecord {
+function createRecordFromResult(
+  chunk: ExecutableChunk,
+  result: ExecutionResult,
+  sourceKind: "chunk" | "inline" = "chunk"
+): ChunkOutputRecord {
   return {
     documentUri: chunk.documentUri,
     chunkId: chunk.identity.chunkId,
@@ -1093,7 +1321,8 @@ function createRecordFromResult(chunk: ExecutableChunk, result: ExecutionResult)
     capturedAt: result.finishedAt,
     stale: false,
     status: result.success ? "success" : "error",
-    outputs: result.items
+    outputs: result.items,
+    sourceKind
   };
 }
 
@@ -1128,11 +1357,30 @@ async function toNotebookOutput(item: OutputItem): Promise<vscode.NotebookCellOu
     return new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(item.html, "text/html")]);
   }
 
+  if (item.type === "markdown") {
+    return new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(item.markdown, "text/markdown")]);
+  }
+
   const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(item.path));
   return new vscode.NotebookCellOutput([
     new vscode.NotebookCellOutputItem(bytes, item.mimeType),
     vscode.NotebookCellOutputItem.text(path.basename(item.path))
   ]);
+}
+
+function inlineSourceOutputItems(source: string): ChunkOutputRecord["outputs"] {
+  return [{ type: "markdown", markdown: source }];
+}
+
+function createInlineSourceOutputs(source: string): vscode.NotebookCellOutput[] {
+  return [new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(source, "text/markdown")])];
+}
+
+function createInlineCellData(source: string, expressionCount: number): vscode.NotebookCellData {
+  const cell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, source, "markdown");
+  cell.metadata = withInlineChunksMetadata(cell.metadata, { kind: "inline", expressionCount });
+  cell.outputs = createInlineSourceOutputs(source);
+  return cell;
 }
 
 function ensureTrailingNewline(value: string): string {

--- a/src/notebook/notebookSource.ts
+++ b/src/notebook/notebookSource.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { parseExecutableChunks } from "../document/chunkParser";
 import { parseChunkOptions } from "./chunkOptions";
 import { parseFrontmatter } from "./frontmatter";
+import { parseInlineRExpressions } from "./inlineR";
 import { getInlineChunksMetadata, withInlineChunksMetadata } from "./notebookTypes";
 
 const DECODER = new TextDecoder();
@@ -71,6 +72,14 @@ export function serializeNotebookSource(data: vscode.NotebookData): Uint8Array {
       continue;
     }
 
+    if (metadata?.kind === "inline") {
+      const markup = normalizeMarkupSource(cell.value);
+      if (markup.length > 0) {
+        blocks.push(markup);
+      }
+      continue;
+    }
+
     if (cell.kind === vscode.NotebookCellKind.Markup) {
       const markup = normalizeMarkupSource(cell.value);
       if (markup.length > 0) {
@@ -91,6 +100,20 @@ export function serializeNotebookSource(data: vscode.NotebookData): Uint8Array {
 
 function pushMarkupCell(cells: vscode.NotebookCellData[], value: string): void {
   if (value.trim().length === 0) {
+    return;
+  }
+
+  const inlineExpressions = parseInlineRExpressions(value);
+  if (inlineExpressions.length > 0) {
+    const inlineCell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, value, "markdown");
+    inlineCell.metadata = withInlineChunksMetadata(inlineCell.metadata, {
+      kind: "inline",
+      expressionCount: inlineExpressions.length
+    });
+    inlineCell.outputs = [
+      new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(value, "text/markdown")])
+    ];
+    cells.push(inlineCell);
     return;
   }
 

--- a/src/notebook/notebookTypes.ts
+++ b/src/notebook/notebookTypes.ts
@@ -24,10 +24,16 @@ export interface InlineChunksFrontmatterCellMetadata {
   closingFence: "---" | "...";
 }
 
+export interface InlineChunksInlineCellMetadata {
+  kind: "inline";
+  expressionCount: number;
+}
+
 export type InlineChunksCellMetadata =
   | InlineChunksCodeCellMetadata
   | InlineChunksMarkupCellMetadata
-  | InlineChunksFrontmatterCellMetadata;
+  | InlineChunksFrontmatterCellMetadata
+  | InlineChunksInlineCellMetadata;
 
 export interface InlineChunksCellMetadataEnvelope {
   rmdNotebooks?: InlineChunksCellMetadata;

--- a/src/test/suite/inlineR.test.ts
+++ b/src/test/suite/inlineR.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "mocha";
+import { buildInlineRExecutionCode, normalizeInlineRForKnitr, parseInlineRExpressions } from "../../notebook/inlineR";
+
+describe("inlineR", () => {
+  it("parses native knitr and Quarto R expressions", () => {
+    const expressions = parseInlineRExpressions("A `r x + 1` and `{r} paste('hello', 'world')`.");
+    assert.deepEqual(expressions.map(({ syntax, expression }) => ({ syntax, expression })), [
+      { syntax: "knitr", expression: "x + 1" },
+      { syntax: "quarto", expression: "paste('hello', 'world')" }
+    ]);
+  });
+
+  it("ignores escaped, doubled-backtick, double-brace, and non-R spans", () => {
+    const markdown = String.raw`\`r escaped\` and \`\`{r} doubled\`\` and \`{{r}} escaped\` and \`python value\``;
+    assert.deepEqual(parseInlineRExpressions(markdown), []);
+  });
+
+  it("normalizes supported syntax for knitr without changing surrounding prose", () => {
+    assert.equal(
+      normalizeInlineRForKnitr("Value `{r} x` and `r y`."),
+      "Value `r x` and `r y`."
+    );
+  });
+
+  it("builds protocol-safe R code for multiline and quoted prose", () => {
+    const code = buildInlineRExecutionCode("It's `r paste(\"hello\", \"world\")`.\nNext.");
+    assert.match(code, /^local\(\{/);
+    assert.ok(code.includes("knitr::knit"));
+    assert.ok(!code.includes("It's"));
+    assert.ok(code.includes("%0A"));
+  });
+});

--- a/src/test/suite/packageManifest.test.ts
+++ b/src/test/suite/packageManifest.test.ts
@@ -9,4 +9,8 @@ describe("package manifest", () => {
   it("makes Rmd Notebooks the default editor for contributed notebook files", () => {
     assert.equal(packageJson.contributes.notebooks[0].priority, "default");
   });
+
+  it("contributes an inline R execution command", () => {
+    assert.ok(packageJson.contributes.commands.some((entry) => entry.command === "rmdNotebooks.runInlineCell"));
+  });
 });

--- a/test/manual-workspace/inline.qmd
+++ b/test/manual-workspace/inline.qmd
@@ -1,0 +1,10 @@
+---
+title: Inline R prose
+---
+
+```{r setup}
+radius <- 5
+```
+
+The radius is `{r} radius`, so the diameter is `r radius * 2`.
+

--- a/test/manual-workspace/inline.rmd
+++ b/test/manual-workspace/inline.rmd
@@ -1,0 +1,11 @@
+---
+title: Inline R prose
+output: html_document
+---
+
+```{r setup}
+greeting <- "hello"
+```
+
+The greeting is `r paste(greeting, "world")`; Quarto syntax also works: `{r} nchar(greeting)`.
+

--- a/test/vscode/suite/extensionHost.test.ts
+++ b/test/vscode/suite/extensionHost.test.ts
@@ -300,6 +300,121 @@ describe("Rmd Notebooks Notebook Host", () => {
     assert.ok(outputText.includes("protocol=FALSE"));
   });
 
+  it("evaluates inline R prose in document order and preserves its source", async () => {
+    await writeFixture(
+      "inline-prose.qmd",
+      [
+        "# Inline prose",
+        "",
+        "```{r setup}",
+        "inline_value <- 41",
+        "```",
+        "",
+        "The answer is `{r} inline_value + 1` and `r paste(\"hello\", \"world\")`.",
+        "",
+        "```{r update}",
+        "inline_value <- inline_value + 1",
+        "```",
+        "",
+        "The updated answer is `r inline_value`.",
+        ""
+      ].join("\n")
+    );
+
+    let editor = await openNotebookEditor("inline-prose.qmd");
+    const inlineCells = editor.notebook.getCells().filter(
+      (cell) => cell.metadata?.rmdNotebooks?.kind === "inline"
+    );
+    assert.equal(inlineCells.length, 2);
+    assert.ok(inlineCells.every((cell) => cell.kind === vscode.NotebookCellKind.Code));
+    assert.ok(inlineCells.every((cell) => cell.document.languageId === "markdown"));
+
+    await vscode.commands.executeCommand("rmdNotebooks.runAllChunks");
+    const state = await waitForDocumentState(
+      editor.notebook.uri,
+      (candidate) => candidate.outputs.length === 4 && candidate.outputs.filter((output) => output.outputTypes.includes("markdown")).length === 2
+    );
+    assert.equal(state.snapshot?.chunkIds.length, 4);
+
+    const firstRendered = await waitForNotebookOutput(inlineCells[0], (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("The answer is 42 and hello world.")
+    );
+    const secondRendered = await waitForNotebookOutput(inlineCells[1], (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("The updated answer is 42.")
+    );
+    assert.ok(notebookOutputText(firstRendered, "text/markdown").includes("The answer is 42 and hello world."));
+    assert.ok(notebookOutputText(secondRendered, "text/markdown").includes("The updated answer is 42."));
+
+    const sourceEdit = new vscode.WorkspaceEdit();
+    sourceEdit.replace(
+      inlineCells[0].document.uri,
+      fullDocumentRange(inlineCells[0].document),
+      inlineCells[0].document.getText().replace("inline_value + 1", "inline_value + 2")
+    );
+    await vscode.workspace.applyEdit(sourceEdit);
+    await waitForDocumentState(
+      editor.notebook.uri,
+      (candidate) => candidate.outputs.some((output) => output.stale && output.outputTypes.includes("markdown"))
+    );
+    await waitForNotebookOutput(inlineCells[0], (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("Stale output")
+    );
+    await vscode.commands.executeCommand(
+      "rmdNotebooks.runInlineCell",
+      editor.notebook.uri.toString(),
+      undefined,
+      inlineCells[0].index
+    );
+    await waitForNotebookOutput(inlineCells[0], (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("The answer is 44 and hello world.")
+    );
+
+    assert.ok(await editor.notebook.save());
+    const savedSource = Buffer.from(await vscode.workspace.fs.readFile(editor.notebook.uri)).toString("utf8");
+    assert.ok(savedSource.includes("The answer is `{r} inline_value + 2` and `r paste"));
+    assert.ok(!savedSource.includes("The answer is 42"));
+
+    await closeAllEditors();
+    editor = await openNotebookEditor("inline-prose.qmd");
+    const reopenedInline = editor.notebook.getCells().find(
+      (cell) => cell.metadata?.rmdNotebooks?.kind === "inline" && cell.document.getText().includes("The answer is")
+    );
+    assert.ok(reopenedInline);
+    await waitForNotebookOutput(reopenedInline, (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("The answer is 44 and hello world.")
+    );
+
+    editor.selection = singleCellRange(reopenedInline.index);
+    await vscode.commands.executeCommand("rmdNotebooks.clearCurrentOutput");
+    await waitForNotebookOutput(reopenedInline, (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("`{r} inline_value + 2`")
+    );
+  });
+
+  it("promotes newly authored inline prose and retains source beside evaluation errors", async () => {
+    await writeFixture("promote-inline.qmd", "# Promotion\n\nPlain prose.\n");
+    const editor = await openNotebookEditor("promote-inline.qmd");
+    const markupIndex = editor.notebook.getCells().findIndex(
+      (cell) => cell.kind === vscode.NotebookCellKind.Markup && cell.document.getText().includes("Plain prose")
+    );
+    assert.ok(markupIndex >= 0);
+    const markup = editor.notebook.cellAt(markupIndex);
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(markup.document.uri, fullDocumentRange(markup.document), "Value: `r stop(\"inline boom\")`.");
+    await vscode.workspace.applyEdit(edit);
+
+    editor.selection = singleCellRange(markupIndex);
+    await vscode.commands.executeCommand("rmdNotebooks.runInlineCell");
+
+    const promoted = editor.notebook.cellAt(markupIndex);
+    assert.equal(promoted.metadata?.rmdNotebooks?.kind, "inline");
+    const rendered = await waitForNotebookOutput(promoted, (cell) =>
+      notebookOutputText(cell, "text/markdown").includes("stop") &&
+      notebookOutputText(cell, "application/vnd.code.notebook.stderr").includes("inline boom")
+    );
+    assert.ok(notebookOutputText(rendered, "text/markdown").includes('Value: `r stop("inline boom")`.'));
+  });
+
   it("honors project .Rprofile startup files by default", async () => {
     await writeFixture(".Rprofile", "rprofile_marker <- 41\n");
     await writeFixture(
@@ -1708,6 +1823,11 @@ function getWorkspaceFileUri(name: string): vscode.Uri {
   const folder = vscode.workspace.workspaceFolders?.[0];
   assert.ok(folder, "A workspace folder should be available for integration tests.");
   return vscode.Uri.joinPath(folder.uri, name);
+}
+
+function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
+  const lastLine = document.lineAt(Math.max(0, document.lineCount - 1));
+  return new vscode.Range(new vscode.Position(0, 0), lastLine.range.end);
 }
 
 function findFirstCodeCellIndex(notebook: vscode.NotebookDocument): number {


### PR DESCRIPTION
## What changed

- parse native knitr `` `r ...` `` and Quarto `` `{r} ...` `` inline expressions
- model inline-bearing prose as source-preserving Markdown code cells with rendered `text/markdown` output
- evaluate prose through knitr in the existing per-document `.GlobalEnv`
- interleave inline prose and fenced chunks in document order during Run All
- persist, restore, stale-mark, clear, cancel, and error-render inline results
- promote newly authored inline prose on first run and expose an `Inline R ×N` status action
- add manual `.Rmd` and `.qmd` fixtures plus user documentation

## Compatibility

- stored output records gain an optional `sourceKind`; existing records default to ordinary chunks
- no npm dependency is added
- `knitr` is checked at execution time with an actionable install error
- inline evaluation is self-contained and does not add protocol helpers to `.GlobalEnv`

## Validation

- `npm run test:unit` — 45 passing
- `npm run test:vscode` — 42 passing
- `npm run package:vsix:marketplace`
- `npm run package:vsix:openvsx`

## PR dependency

This PR targets `fix/yaml-frontmatter-cell` because it builds on PR #22's non-executable frontmatter cell metadata. After #22 merges, retarget this PR to `main`; its feature commit remains separate.

Fixes #20

## Screenshots

<img width="604" height="196" alt="image" src="https://github.com/user-attachments/assets/6f67406a-92d5-44ac-a36a-4359b11259c0" />
