### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.0
 
 - show document frontmatter as an editable, syntax-highlighted YAML cell without making it executable (#19)
 - evaluate native knitr and Quarto inline R expressions in rendered, source-preserving prose cells (#20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmd-notebooks-vscode",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmd-notebooks-vscode",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rmd-notebooks-vscode",
   "displayName": "Rmd Notebooks for VS Code",
   "description": "Open .Rmd and .qmd files as runnable R notebooks in VS Code and Positron.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "publisher": "AlFontal",
   "author": "Alejandro Fontal",
   "license": "MIT",


### PR DESCRIPTION
## Release

Prepare Rmd Notebooks 0.5.0 with:

- editable, non-executable YAML frontmatter cells (#19)
- persisted inline R prose using knitr and Quarto syntax (#20)
- HTML preview from `.Rmd` and `.qmd` notebook views (#21)

## Changes

- bump `package.json` and `package-lock.json` to `0.5.0`
- promote the Unreleased changelog section to `0.5.0`

## Validation

- release tag check passes for `v0.5.0`
- 46 unit tests passing
- 44 extension-host tests passing
- Marketplace VSIX packages successfully
- Open VSX VSIX packages successfully

Publishing GitHub release `v0.5.0` after merge will trigger the existing release workflow for both registries.